### PR TITLE
Add %i formatting syntax

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -1286,7 +1286,7 @@
 							<key>comment</key>
 							<string>Operator symbols</string>
 							<key>match</key>
-							<string>((\%([\+\-0]?\d{0,3}(\.\d{1,3})?)(c|d|e|E|f|g|G|s|((b|t)?(o|u|x|X))))|\%\%|\\(b|f|n|r|t|\\))</string>
+							<string>((\%([\+\-0]?\d{0,3}(\.\d{1,3})?)(c|d|e|E|f|g|G|i|s|((b|t)?(o|u|x|X))))|\%\%|\\(b|f|n|r|t|\\))</string>
 							<key>name</key>
 							<string>constant.character.escape.matlab</string>
 						</dict>


### PR DESCRIPTION
`%i` is an alternative to `%d` in *printf strings \[[ref](https://www.mathworks.com/help/matlab/ref/fprintf.html?s_tid=doc_ta#btf8xsy-1_sep_shared-formatSpec)\]. This PR just adds this to the list of formats.