### PR TITLE
Add handling for property validation

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -751,6 +751,40 @@
 							<key>patterns</key>
 							<array>
 								<dict>
+									<key>comment</key>
+									<string>     1 property name           2 size          3 type                       4 validator function</string>
+									<key>match</key>
+									<string>^\s*([a-zA-Z][a-zA-Z0-9_]*)\s*(\([^\)]*\))?\s*([a-zA-Z][a-zA-Z0-9_\.]*)?\s*({[^}]*})?\s*(.*)$</string>
+									<key>captures</key>
+									<dict>
+										<key>2</key>
+										<dict>
+											<key>name</key>
+											<string>storage.type.matlab</string>
+										</dict>
+										<key>3</key>
+										<dict>
+											<key>name</key>
+											<string>storage.type.matlab</string>
+										</dict>
+										<key>4</key>
+										<dict>
+											<key>name</key>
+											<string>storage.type.matlab</string>
+										</dict>
+										<key>5</key>
+										<dict>
+											<key>patterns</key>
+											<array>
+												<dict>
+													<key>include</key>
+													<string>$self</string>
+												</dict>
+											</array>
+										</dict>
+									</dict>
+								</dict>
+								<dict>
 									<key>include</key>
 									<string>$self</string>
 								</dict>

--- a/PropertyValidation.m
+++ b/PropertyValidation.m
@@ -1,0 +1,16 @@
+classdef PropertyValidation
+    properties (GetAccess = 'public', SetAccess = 'private')
+        % Commentary in the properties block
+        Prop % comment
+        PropType some.type
+        PropSize (1,2) % comment
+        PropSizeType (:, 3) int64
+        PropSizeTypeFcn  (:, 3) foo.bar.baz {mustBeReal}
+        PropInit = "string"
+        PropTypeInit some.type = some.type(1)
+        PropSizeInit (1,2) = 'char'
+        PropSizeTypeInit (:, 3, 6) int64 = rand
+        PropSizeTypeFcnInit  (:, 3) foo.bar.baz {mustBeReal} = pi;
+        % Ending commentary
+    end
+end


### PR DESCRIPTION
Fixes #8. Tested in VSCode.
**Before**
![vscodePropValidateBefore](https://user-images.githubusercontent.com/43882944/64068563-d14f8e00-cc07-11e9-9b47-c8c60092c071.png)

**After**
![vscodePropValidateAfter](https://user-images.githubusercontent.com/43882944/64068564-d7456f00-cc07-11e9-8b24-704814b8aa04.png)

**After with theme from https://github.com/Gimly/vscode-matlab/issues/89**
![vscodePropValidateAfterLight](https://user-images.githubusercontent.com/43882944/64068579-12e03900-cc08-11e9-8f21-165104febc88.png)
