### PR TITLE
Fix property comments after semicolon and multi-line classdef

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -583,21 +583,8 @@
 							(^\s*)								# Leading whitespace
 							(classdef)
 							\b\s*
-							(									# Optional attributes
-								\( [^)]* \)
-							)?
-							\s*
-							(
-								([a-zA-Z][a-zA-Z0-9_]*)			# Class name
-								(?:								# Optional inheritance
-									\s*
-									(&lt;)
-									\s*
-									([^%]*)
-								)?
-							)
-							\s*($|(?=%))
-						</string>
+							(.*)
+					</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -611,61 +598,89 @@
 							<array>
 								<dict>
 									<key>match</key>
-									<string>[a-zA-Z][a-zA-Z0-9_]*</string>
-									<key>name</key>
-									<string>variable.parameter.class.matlab</string>
-								</dict>
-								<dict>
-									<key>begin</key>
-									<string>=\s*</string>
-									<key>end</key>
-									<string>,|(?=\))</string>
-									<key>patterns</key>
-									<array>
+									<string>(?x)
+										(									# Optional attributes
+											 \( [^)]* \)
+										)?
+										\s*
+										(
+											([a-zA-Z][a-zA-Z0-9_]*)			# Class name
+											(?:								# Optional inheritance
+												\s*
+												(&lt;)
+												\s*
+												([^%]*)
+											)?
+										)
+										\s*($|(?=(%|...)))
+									</string>
+									<key>captures</key>
+									<dict>
+										<key>1</key>
 										<dict>
-											<key>match</key>
-											<string>true|false</string>
+											<key>patterns</key>
+											<array>
+												<dict>
+													<key>match</key>
+													<string>[a-zA-Z][a-zA-Z0-9_]*</string>
+													<key>name</key>
+													<string>variable.parameter.class.matlab</string>
+												</dict>
+												<dict>
+													<key>begin</key>
+													<string>=\s*</string>
+													<key>end</key>
+													<string>,|(?=\))</string>
+													<key>patterns</key>
+													<array>
+														<dict>
+															<key>match</key>
+															<string>true|false</string>
+															<key>name</key>
+															<string>constant.language.boolean.matlab</string>
+														</dict>
+														<dict>
+															<key>include</key>
+															<string>#string</string>
+														</dict>
+													</array>
+												</dict>
+											</array>
+										</dict>
+										<key>2</key>
+										<dict>
 											<key>name</key>
-											<string>constant.language.boolean.matlab</string>
+											<string>meta.class-declaration.matlab</string>
 										</dict>
+										<key>3</key>
 										<dict>
-											<key>include</key>
-											<string>#string</string>
+											<key>name</key>
+											<string>entity.name.section.class.matlab</string>
 										</dict>
-									</array>
-								</dict>
-							</array>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>meta.class-declaration.matlab</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>entity.name.section.class.matlab</string>
-						</dict>
-						<key>6</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.other.matlab</string>
-						</dict>
-						<key>7</key>
-						<dict>
-							<key>patterns</key>
-							<array>
-								<dict>
-									<key>match</key>
-									<string>[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)*</string>
-									<key>name</key>
-									<string>entity.other.inherited-class.matlab</string>
-								</dict>
-								<dict>
-									<key>match</key>
-									<string>&amp;</string>
-									<key>name</key>
-									<string>keyword.operator.other.matlab</string>
+										<key>4</key>
+										<dict>
+											<key>name</key>
+											<string>keyword.operator.other.matlab</string>
+										</dict>
+										<key>5</key>
+										<dict>
+											<key>patterns</key>
+											<array>
+												<dict>
+													<key>match</key>
+													<string>[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)*</string>
+													<key>name</key>
+													<string>entity.other.inherited-class.matlab</string>
+												</dict>
+												<dict>
+													<key>match</key>
+													<string>&amp;</string>
+													<key>name</key>
+													<string>keyword.operator.other.matlab</string>
+												</dict>
+											</array>
+										</dict>
+									</dict>
 								</dict>
 							</array>
 						</dict>
@@ -1458,9 +1473,9 @@
 			<key>comment</key>
 			<string>Property and argument validation. Match an identifier allowing . and ?.</string>
 			<key>begin</key>
-			<string>\s*[,;]?\s*([a-zA-Z][a-zA-Z0-9_\.\?]*)</string>
+			<string>\s*[;]?\s*([a-zA-Z][a-zA-Z0-9_\.\?]*)</string>
 			<key>end</key>
-			<string>([,;\n%=].*)</string>
+			<string>([;\n%=].*)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -1490,7 +1505,7 @@
 							<key>comment</key>
 							<string>Handle things like arg = val; nextArg</string>
 							<key>match</key>
-							<string>(=[^;,]*)</string>
+							<string>(=[^;]*)</string>
 							<key>captures</key>
 							<dict>
 								<key>1</key>
@@ -1507,9 +1522,9 @@
 						</dict>
 						<dict>
 							<key>comment</key>
-							<string>End of property/argument patterns which start a new property/argument</string>
+							<string>End of property/argument patterns which start a new property/argument. Look for beginning of identifier after semicolon. Otherwise treat as regular code.</string>
 							<key>match</key>
-							<string>([\n,;].*)</string>
+							<string>([\n;]\s*[a-zA-Z].*)</string>
 							<key>captures</key>
 							<dict>
 								<key>1</key>
@@ -1523,6 +1538,10 @@
 									</array>
 								</dict>
 							</dict>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
 						</dict>
 					</array>
 				</dict>

--- a/PropertyValidation.m
+++ b/PropertyValidation.m
@@ -4,7 +4,7 @@ classdef PropertyValidation
         Prop % comment
         PropType some.type
         PropSize (1,2) % comment
-        PropSizeType (:, 3) int64
+        PropSizeType (:, 3) int64; % another comment
         PropSizeTypeFcn  (:, 3) foo.bar.baz {mustBeReal}
         PropInit = "string"
         PropTypeInit some.type = some.type(1)


### PR DESCRIPTION
Fixes #16 and #15. Tested in vscode and atom.

**Before**
![vscodeClassdefPropCommentBefore](https://user-images.githubusercontent.com/43882944/68298175-b7e31c00-0066-11ea-80d8-ff3cdd902193.png)

**After**
![vscodeClassdefPropCommentAfter](https://user-images.githubusercontent.com/43882944/68298181-bb76a300-0066-11ea-926c-2484c776f2a4.png)
