### PR TITLE
Fix comment highlighting after properties|events|methods|enumeration block headers

### DIFF
--- a/Account.m
+++ b/Account.m
@@ -1,7 +1,7 @@
 classdef Account < handle & BaseAccount % Models a bank account
    % Some properties
    properties
-   	Value 
+   	Value
    end
    % Some methods
    methods
@@ -9,12 +9,12 @@ classdef Account < handle & BaseAccount % Models a bank account
        function obj = Account(value)
            obj.Value = value;
        end
-       
+
       function obj = BasicClass(val)
          if nargin == 1
             if isnumeric(val)
                obj.Value = val;
-	    else 
+	    else
                error('Value must be numeric')
             end
          end
@@ -42,11 +42,11 @@ classdef Account < handle & BaseAccount % Models a bank account
       end
    end
 	% Some events
-    events (ListenAccess = protected)
+    events (ListenAccess = protected) % A comment
        StateChanged
     end
    % Some enumeration
-    enumeration
+    enumeration % A comment
        No  (0)
        Yes (1)
     end

--- a/CircleArea.m
+++ b/CircleArea.m
@@ -1,11 +1,11 @@
-classdef CircleArea
-   properties
+classdef CircleArea % A comment
+   properties  % A comment
       Radius
    end
    properties (Constant)
       P = pi
    end
-   properties (Dependent)
+   properties (Dependent) % A comment
       Area
    end
    methods
@@ -33,7 +33,7 @@ classdef CircleArea
          line([0,r],[r,r])
          text(r/2,r+.5,['r = ',num2str(r)])
          title(['Area = ',num2str(obj.Area)])
-         
+
          % This is an example of a command dual
          axis equal
       end
@@ -42,7 +42,7 @@ classdef CircleArea
          disp(['Circle with radius: ',num2str(rad)])
       end
    end
-   methods (Static)
+   methods (Static) % A comment
       function obj = createObj
          prompt = {"Enter the Radius"};
          dlgTitle = 'Radius';

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -598,7 +598,7 @@
 							<key>begin</key>
 							<string>(?x)
 									(^\s*)								# Leading whitespace
-									(properties)\b(.*)$
+									(properties)\b([^%]*)
 									\s*
 									(									# Optional attributes
 										\( [^)]* \)
@@ -674,7 +674,7 @@
 							<key>begin</key>
 							<string>(?x)
 									(^\s*)								# Leading whitespace
-									(methods)\b(.*)$
+									(methods)\b([^%]*)
 									\s*
 									(									# Optional attributes
 										\( [^)]* \)
@@ -746,7 +746,7 @@
 							<key>begin</key>
 							<string>(?x)
 									(^\s*)								# Leading whitespace
-									(events)\b(.*)$
+									(events)\b([^%]*)
 									\s*
 									(									# Optional attributes
 										\( [^)]* \)
@@ -806,12 +806,19 @@
 							</dict>
 							<key>name</key>
 							<string>meta.events.matlab</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
 						</dict>
 						<dict>
 							<key>begin</key>
 							<string>(?x)
 									(^\s*)								# Leading whitespace
-									(enumeration)\b(.*)$
+									(enumeration)\b([^%]*)
 									\s*($|(?=%))
 								</string>
 							<key>beginCaptures</key>


### PR DESCRIPTION
Fixes #24   Tested in VSCode and Atom

**Before**

![vscodeMethodBlocksCommentsAfter](https://user-images.githubusercontent.com/43882944/70911866-bea76c00-1fe0-11ea-98c3-f873142c845a.png)


**After**
![vscodeMethodBlocksCommentsBefore](https://user-images.githubusercontent.com/43882944/70911867-bea76c00-1fe0-11ea-9a07-c45839115e3c.png)
