### PR TITLE
Classdef line comment highlighting

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -507,7 +507,7 @@
 												([^%]*)
 											)?
 										)
-										\s*($|(?=(%|...)))
+										\s*($|(?=(%|...)).*)
 									</string>
 									<key>captures</key>
 									<dict>
@@ -572,6 +572,16 @@
 													<string>&amp;</string>
 													<key>name</key>
 													<string>keyword.operator.other.matlab</string>
+												</dict>
+											</array>
+										</dict>
+										<key>6</key>
+										<dict>
+											<key>patterns</key>
+											<array>
+												<dict>
+													<key>include</key>
+													<string>$self</string>
 												</dict>
 											</array>
 										</dict>


### PR DESCRIPTION
```matlab
classdef MyClass % A comment
end
```
doesn't highlight the comment properly. This fixes that.

Tested in vscode and atom.

**before**
![vscodeClassdefCommentBefore](https://user-images.githubusercontent.com/43882944/72662823-bebcd200-39b9-11ea-9289-6ca6b43e87d2.png)


**after**
![vscodeClassdefCommentAfter](https://user-images.githubusercontent.com/43882944/72662817-b6649700-39b9-11ea-915a-93e7816c063f.png)
