### PR TITLE
Travis xmllint test for grammar file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: minimal
+
+before_install:
+  - sudo apt-get -y install libxml2-utils
+
+jobs:
+  include:
+    - stage: test
+      script:
+        - xmllint --noout Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage


### PR DESCRIPTION
Set up and tested on my fork. My PR seems to have run in Travis so there may be no extra config needed other than this file. See the "All checks have passed" section below

The test builds of my fork are at:

https://travis-ci.com/rlivings39/MATLAB-Language-grammar

including a build where I injected the same bug from #32 to verify that it fails the build:

https://travis-ci.com/rlivings39/MATLAB-Language-grammar/builds/146682462