### PR TITLE
Fix import module and `varargin{:}` highlighting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.m": "matlab"
+    }
+}

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -1094,7 +1094,7 @@
 								<key>1</key>
 								<dict>
 									<key>name</key>
-									<string>keyword.control.end.event.matlab</string>
+									<string>keyword.control.end.events.matlab</string>
 								</dict>
 							</dict>
 							<key>patterns</key>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -946,7 +946,7 @@
 								<key>1</key>
 								<dict>
 									<key>name</key>
-									<string>keyword.control.properties.end.matlab</string>
+									<string>keyword.control.end.properties.matlab</string>
 								</dict>
 							</dict>
 							<key>patterns</key>
@@ -1022,7 +1022,7 @@
 								<key>1</key>
 								<dict>
 									<key>name</key>
-									<string>keyword.control.methods.end.matlab</string>
+									<string>keyword.control.end.methods.matlab</string>
 								</dict>
 							</dict>
 							<key>patterns</key>
@@ -1094,7 +1094,7 @@
 								<key>1</key>
 								<dict>
 									<key>name</key>
-									<string>keyword.control.events.end.matlab</string>
+									<string>keyword.control.end.event.matlab</string>
 								</dict>
 							</dict>
 							<key>patterns</key>
@@ -1143,7 +1143,7 @@
 								<key>1</key>
 								<dict>
 									<key>name</key>
-									<string>keyword.control.enum.end.matlab</string>
+									<string>keyword.control.end.enum.matlab</string>
 								</dict>
 							</dict>
 							<key>patterns</key>
@@ -1623,7 +1623,7 @@
 								<key>1</key>
 								<dict>
 									<key>name</key>
-									<string>keyword.control.arguments.end.matlab</string>
+									<string>keyword.control.end.arguments.matlab</string>
 								</dict>
 							</dict>
 							<key>patterns</key>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -2414,7 +2414,7 @@
 					<key>name</key>
 					<string>keyword.operator.vector.colon.matlab</string>
 					<key>match</key>
-					<string>(?&lt;=[a-zA-Z0-9_\s(),]|^):(?=[a-zA-Z0-9_\s(),]|$)</string>
+					<string>(?&lt;=[a-zA-Z0-9_\s(){,]|^):(?=[a-zA-Z0-9_\s()},]|$)</string>
 				</dict>
 				<dict>
 					<key>comment</key>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -1732,35 +1732,42 @@
 			<string>Import statement</string>
 			<key>name</key>
 			<string>meta.import.matlab</string>
-			<key>contentName</key>
-			<string>entity.name.namespace.matlab</string>
-			<key>begin</key>
-			<string>\b(import)\b[^\S\n]+(?=\w)</string>
-			<key>beginCaptures</key>
+			<key>match</key>
+			<string>\b(import)\b[^\S\n]+([a-zA-Z0-9.]*)(?=;|%|$)</string>
+			<key>captures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>keyword.other.import.matlab</string>
 				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.namespace.matlab</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>name</key>
+							<string>entity.name.module.matlab</string>
+							<key>match</key>
+							<string>\w+</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.matlab</string>
+							<key>match</key>
+							<string>\.</string>
+						</dict>
+						<dict>
+							<key>name</key>
+							<string>variable.language.wildcard.matlab</string>
+							<key>match</key>
+							<string>\*</string>
+						</dict>
+					</array>
+				</dict>
 			</dict>
-			<key>end</key>
-			<string>(?=;|\n|%)</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>name</key>
-					<string>punctuation.separator.matlab</string>
-					<key>match</key>
-					<string>\.</string>
-				</dict>
-				<dict>
-					<key>name</key>
-					<string>variable.language.wildcard.matlab</string>
-					<key>match</key>
-					<string>\*</string>
-				</dict>
-			</array>
 		</dict>
 		<key>indexing_by_expression</key>
 		<dict>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matlab-language-grammar",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "MATLAB TextMate grammar",
   "scripts": {
     "testGrammar": "vscode-tmgrammar-test -s source.matlab -g Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage -t \"./test/*.m\"",

--- a/test/snap/Account.m.snap
+++ b/test/snap/Account.m.snap
@@ -25,7 +25,7 @@
 #        ^^^^^ source.matlab meta.class.matlab meta.properties.matlab meta.assignment.definition.property.matlab variable.object.property.matlab
 >    end
 #^^^^ source.matlab meta.class.matlab meta.properties.matlab
-#    ^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.properties.end.matlab
+#    ^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.end.properties.matlab
 >    % Some methods
 #^^^^ source.matlab meta.class.matlab punctuation.whitespace.comment.leading.matlab
 #    ^ source.matlab meta.class.matlab comment.line.percentage.matlab punctuation.definition.comment.matlab
@@ -327,7 +327,7 @@
 #        ^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab storage.type.function.end.matlab
 >    end
 #^^^^ source.matlab meta.class.matlab meta.methods.matlab
-#    ^^^ source.matlab meta.class.matlab meta.methods.matlab keyword.control.methods.end.matlab
+#    ^^^ source.matlab meta.class.matlab meta.methods.matlab keyword.control.end.methods.matlab
 >    % Some events
 #^^^^ source.matlab meta.class.matlab punctuation.whitespace.comment.leading.matlab
 #    ^ source.matlab meta.class.matlab comment.line.percentage.matlab punctuation.definition.comment.matlab
@@ -352,7 +352,7 @@
 #        ^^^^^^^^^^^^ source.matlab meta.class.matlab meta.events.matlab meta.assignment.definition.event.matlab entity.name.type.event.matlab
 >    end
 #^^^^ source.matlab meta.class.matlab meta.events.matlab
-#    ^^^ source.matlab meta.class.matlab meta.events.matlab keyword.control.events.end.matlab
+#    ^^^ source.matlab meta.class.matlab meta.events.matlab keyword.control.end.events.matlab
 >    % Some enumeration
 #^^^^ source.matlab meta.class.matlab punctuation.whitespace.comment.leading.matlab
 #    ^ source.matlab meta.class.matlab comment.line.percentage.matlab punctuation.definition.comment.matlab
@@ -379,6 +379,6 @@
 #              ^ source.matlab meta.class.matlab meta.enum.matlab punctuation.section.parens.end.matlab
 >    end
 #^^^^ source.matlab meta.class.matlab meta.enum.matlab
-#    ^^^ source.matlab meta.class.matlab meta.enum.matlab keyword.control.enum.end.matlab
+#    ^^^ source.matlab meta.class.matlab meta.enum.matlab keyword.control.end.enum.matlab
 >end
 #^^^ source.matlab meta.class.matlab storage.type.class.end.matlab

--- a/test/snap/AnEnum.m.snap
+++ b/test/snap/AnEnum.m.snap
@@ -46,7 +46,7 @@
 #         ^^^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.enum.matlab comment.line.percentage.matlab
 >    end
 #^^^^ source.matlab meta.class.matlab meta.enum.matlab
-#    ^^^ source.matlab meta.class.matlab meta.enum.matlab keyword.control.enum.end.matlab
+#    ^^^ source.matlab meta.class.matlab meta.enum.matlab keyword.control.end.enum.matlab
 >end
 #^^^ source.matlab meta.class.matlab storage.type.class.end.matlab
 >

--- a/test/snap/CircleArea.m.snap
+++ b/test/snap/CircleArea.m.snap
@@ -16,7 +16,7 @@
 #      ^^^^^^ source.matlab meta.class.matlab meta.properties.matlab meta.assignment.definition.property.matlab variable.object.property.matlab
 >   end
 #^^^ source.matlab meta.class.matlab meta.properties.matlab
-#   ^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.properties.end.matlab
+#   ^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.end.properties.matlab
 >   properties (Constant)
 #^^^ source.matlab meta.class.matlab meta.properties.matlab
 #   ^^^^^^^^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.properties.matlab
@@ -32,7 +32,7 @@
 #          ^^ source.matlab meta.class.matlab meta.properties.matlab meta.assignment.definition.property.matlab constant.numeric.matlab
 >   end
 #^^^ source.matlab meta.class.matlab meta.properties.matlab
-#   ^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.properties.end.matlab
+#   ^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.end.properties.matlab
 >   properties (Dependent) % A comment
 #^^^ source.matlab meta.class.matlab meta.properties.matlab
 #   ^^^^^^^^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.properties.matlab
@@ -46,7 +46,7 @@
 #      ^^^^ source.matlab meta.class.matlab meta.properties.matlab meta.assignment.definition.property.matlab variable.object.property.matlab
 >   end
 #^^^ source.matlab meta.class.matlab meta.properties.matlab
-#   ^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.properties.end.matlab
+#   ^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.end.properties.matlab
 >   methods
 #^^^ source.matlab meta.class.matlab meta.methods.matlab
 #   ^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab keyword.control.methods.matlab
@@ -347,7 +347,7 @@
 #      ^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab storage.type.function.end.matlab
 >   end
 #^^^ source.matlab meta.class.matlab meta.methods.matlab
-#   ^^^ source.matlab meta.class.matlab meta.methods.matlab keyword.control.methods.end.matlab
+#   ^^^ source.matlab meta.class.matlab meta.methods.matlab keyword.control.end.methods.matlab
 >   methods (Static) % A comment
 #^^^ source.matlab meta.class.matlab meta.methods.matlab
 #   ^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab keyword.control.methods.matlab
@@ -432,7 +432,7 @@
 #      ^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab storage.type.function.end.matlab
 >   end
 #^^^ source.matlab meta.class.matlab meta.methods.matlab
-#   ^^^ source.matlab meta.class.matlab meta.methods.matlab keyword.control.methods.end.matlab
+#   ^^^ source.matlab meta.class.matlab meta.methods.matlab keyword.control.end.methods.matlab
 >end
 #^^^ source.matlab meta.class.matlab storage.type.class.end.matlab
 >

--- a/test/snap/CircleArea.m.snap
+++ b/test/snap/CircleArea.m.snap
@@ -412,7 +412,7 @@
 #                       ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.function-call.parens.matlab punctuation.section.parens.begin.matlab
 #                        ^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.function-call.parens.matlab
 #                           ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.function-call.parens.matlab
-#                            ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.function-call.parens.matlab
+#                            ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.function-call.parens.matlab keyword.operator.vector.colon.matlab
 #                             ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.function-call.parens.matlab
 #                              ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.function-call.parens.matlab punctuation.section.parens.end.matlab
 #                               ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab punctuation.terminator.semicolon.matlab

--- a/test/snap/PropertyValidation.m.snap
+++ b/test/snap/PropertyValidation.m.snap
@@ -164,7 +164,7 @@
 #         ^^^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.properties.matlab comment.line.percentage.matlab
 >    end
 #^^^^ source.matlab meta.class.matlab meta.properties.matlab
-#    ^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.properties.end.matlab
+#    ^^^ source.matlab meta.class.matlab meta.properties.matlab keyword.control.end.properties.matlab
 >end
 #^^^ source.matlab meta.class.matlab storage.type.class.end.matlab
 >

--- a/test/snap/argumentValidation.m.snap
+++ b/test/snap/argumentValidation.m.snap
@@ -106,7 +106,7 @@
 #         ^^^^^^^^^^^^^^^^^^ source.matlab meta.function.matlab meta.arguments.matlab comment.line.percentage.matlab
 >    end
 #^^^^ source.matlab meta.function.matlab meta.arguments.matlab
-#    ^^^ source.matlab meta.function.matlab meta.arguments.matlab keyword.control.arguments.end.matlab
+#    ^^^ source.matlab meta.function.matlab meta.arguments.matlab keyword.control.end.arguments.matlab
 >    arguments (Repeating)
 #^^^^ source.matlab meta.function.matlab meta.arguments.matlab
 #    ^^^^^^^^^ source.matlab meta.function.matlab meta.arguments.matlab keyword.control.arguments.matlab
@@ -147,7 +147,7 @@
 #                                                                        ^ source.matlab meta.function.matlab meta.arguments.matlab meta.assignment.definition.property.matlab punctuation.section.block.end.matlab
 >    end
 #^^^^ source.matlab meta.function.matlab meta.arguments.matlab
-#    ^^^ source.matlab meta.function.matlab meta.arguments.matlab keyword.control.arguments.end.matlab
+#    ^^^ source.matlab meta.function.matlab meta.arguments.matlab keyword.control.end.arguments.matlab
 >    arguments
 #^^^^ source.matlab meta.function.matlab meta.arguments.matlab
 #    ^^^^^^^^^ source.matlab meta.function.matlab meta.arguments.matlab keyword.control.arguments.matlab
@@ -174,6 +174,6 @@
 #                                           ^ source.matlab meta.function.matlab meta.arguments.matlab meta.assignment.definition.property.matlab punctuation.section.block.end.matlab
 >    end
 #^^^^ source.matlab meta.function.matlab meta.arguments.matlab
-#    ^^^ source.matlab meta.function.matlab meta.arguments.matlab keyword.control.arguments.end.matlab
+#    ^^^ source.matlab meta.function.matlab meta.arguments.matlab keyword.control.end.arguments.matlab
 >end
 #^^^ source.matlab meta.function.matlab storage.type.function.end.matlab

--- a/test/t16CommentAfterClassdefBlockMembers.m
+++ b/test/t16CommentAfterClassdefBlockMembers.m
@@ -9,23 +9,23 @@ classdef t16CommentAfterClassdefBlockMembers < handle
         end
 %       ^^^ storage.type.function.end.matlab
     end
-%   ^^^ keyword.control.methods.end.matlab
+%   ^^^ keyword.control.end.methods.matlab
     events
         AnEvent % comment
 %       ^^^^^^^ entity.name.type.event.matlab
 %               ^^^^^^^^^ comment.line.percentage.matlab
     end
-%   ^^^ keyword.control.events.end.matlab
+%   ^^^ keyword.control.end.events.matlab
     properties
         SomeProperty % comment
 %       ^^^^^^^^^^^^ variable.object.property.matlab
 %                    ^^^^^^^^^ comment.line.percentage.matlab
     end
-%   ^^^ keyword.control.properties.end.matlab
+%   ^^^ keyword.control.end.properties.matlab
     enumeration
         EnumValue % comment
 %       ^^^^^^^^^ variable.other.enummember.matlab
 %                 ^^^^^^^^^ comment.line.percentage.matlab
     end
-%   ^^^ keyword.control.enum.end.matlab
+%   ^^^ keyword.control.end.enum.matlab
 end


### PR DESCRIPTION
Fix import module highlighting and make keyword control end tokens consistent with Microsoft convention.

CLA signed per https://github.com/mathworks/MATLAB-Language-grammar/pull/37#issuecomment-847052613.