### PR TITLE
Limit single variable assignments to structs and variables

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -1936,7 +1936,7 @@
 				We don't include $self here to avoid matching command syntax inside (), [], {}
 			</string>
 			<key>match</key>
-			<string>(?&lt;=^|;|for)\s*([a-zA-Z][a-zA-Z0-9_.]*)(?=\s*=)</string>
+			<string>(?&lt;=^|,|;|for)\s*([a-zA-Z][a-zA-Z0-9_.]*)(?=\s*=)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -1936,7 +1936,7 @@
 				We don't include $self here to avoid matching command syntax inside (), [], {}
 			</string>
 			<key>match</key>
-			<string>(?&lt;=^|,|;|for)\s*([a-zA-Z][a-zA-Z0-9_.(){}]*)(?=\s*=)</string>
+			<string>(?&lt;=^|;|for)\s*([a-zA-Z][a-zA-Z0-9_.]*)(?=\s*=)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>

--- a/test/snap/Account.m.snap
+++ b/test/snap/Account.m.snap
@@ -195,25 +195,25 @@
 #                      ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab variable.other.readwrite.matlab
 #                       ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab punctuation.separator.comma.matlab
 #                        ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab
-#                         ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.assignment.variable.single.matlab variable.other.readwrite.matlab
-#                          ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.assignment.variable.single.matlab
-#                           ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab
-#                            ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab keyword.operator.assignment.matlab
-#                             ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab
-#                              ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab constant.numeric.decimal.matlab
-#                               ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab
-#                                ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab punctuation.section.parens.begin.matlab
-#                                 ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.parens.matlab variable.other.readwrite.matlab
-#                                  ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.parens.matlab
-#                                   ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.parens.matlab keyword.operator.arithmetic.matlab
-#                                    ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.parens.matlab
-#                                     ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.parens.matlab variable.other.readwrite.matlab
-#                                      ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.parens.matlab
-#                                       ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.parens.matlab keyword.operator.arithmetic.matlab
-#                                        ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.parens.matlab
-#                                         ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab meta.parens.matlab constant.numeric.decimal.matlab
-#                                          ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab punctuation.section.parens.end.matlab
-#                                           ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab punctuation.terminator.semicolon.matlab
+#                         ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab variable.other.readwrite.matlab
+#                          ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.function-call.parens.matlab punctuation.section.parens.end.matlab
+#                           ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab
+#                            ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab keyword.operator.assignment.matlab
+#                             ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab
+#                              ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab constant.numeric.decimal.matlab
+#                               ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab
+#                                ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab punctuation.section.parens.begin.matlab
+#                                 ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.parens.matlab variable.other.readwrite.matlab
+#                                  ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.parens.matlab
+#                                   ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.parens.matlab keyword.operator.arithmetic.matlab
+#                                    ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.parens.matlab
+#                                     ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.parens.matlab variable.other.readwrite.matlab
+#                                      ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.parens.matlab
+#                                       ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.parens.matlab keyword.operator.arithmetic.matlab
+#                                        ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.parens.matlab
+#                                         ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab meta.parens.matlab constant.numeric.decimal.matlab
+#                                          ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab punctuation.section.parens.end.matlab
+#                                           ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab punctuation.terminator.semicolon.matlab
 >                end
 #^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab
 #                ^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.for.matlab meta.for.matlab keyword.control.end.for.matlab


### PR DESCRIPTION
Workaround for meta scoping being broken on matrix or cell assignments.

This will also prevent broken scoping from appearing in the VS Code extension and its language service.