### PR TITLE
Fixes for multiple function definitions

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -1454,7 +1454,7 @@
 							<key>begin</key>
 							<string>\G</string>
 							<key>end</key>
-							<string>(?&lt;=[\)\n])</string>
+							<string>(?&lt;=\))|(?&gt;(?&lt;!\.\.\..*)\n)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -1463,7 +1463,7 @@
 									<key>contentName</key>
 									<string>meta.assignment.variable.output.matlab</string>
 									<key>begin</key>
-									<string>\G(?=.*?=)</string>
+									<string>\G(?=[^\(]*?(?:=|\[|\.{3}))</string>
 									<key>end</key>
 									<string>\s*(=)\s*</string>
 									<key>endCaptures</key>
@@ -1484,7 +1484,7 @@
 										</dict>
 										<dict>
 											<key>match</key>
-											<string>(\])\s*\z</string>
+											<string>(\])\s*</string>
 											<key>captures</key>
 											<dict>
 												<key>1</key>
@@ -1508,11 +1508,11 @@
 										</dict>
 										<dict>
 											<key>include</key>
-											<string>#comments</string>
+											<string>#line_continuation</string>
 										</dict>
 										<dict>
 											<key>include</key>
-											<string>#line_continuation</string>
+											<string>#comments</string>
 										</dict>
 									</array>
 								</dict>
@@ -1522,7 +1522,7 @@
 									<key>name</key>
 									<string>entity.name.function.matlab</string>
 									<key>match</key>
-									<string>[a-zA-Z][a-zA-Z0-9_.]*(?=[^a-zA-Z0-9_.])</string>
+									<string>[a-zA-Z][a-zA-Z0-9_]*(?&gt;\.[a-zA-Z0-9_]+)*</string>
 									<key>patterns</key>
 									<array>
 										<dict>
@@ -1543,7 +1543,7 @@
 									<key>name</key>
 									<string>meta.parameters.matlab</string>
 									<key>begin</key>
-									<string>(?&lt;=[a-zA-Z0-9_])\s*\(</string>
+									<string>\s*\(</string>
 									<key>end</key>
 									<string>\)</string>
 									<key>beginCaptures</key>
@@ -1591,6 +1591,10 @@
 											<string>#line_continuation</string>
 										</dict>
 									</array>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#line_continuation</string>
 								</dict>
 								<dict>
 									<key>include</key>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -227,7 +227,7 @@
 					<key>begin</key>
 					<string>(?&lt;=\))[^\S\n]*(\()?</string>
 					<key>end</key>
-					<string>(\))?[^\S\n]*(?=;|(?&lt;!(?:\.\.\..*))\n|%)</string>
+					<string>(\))?[^\S\n]*(?=;|(?&lt;!(?:\.{3}.*))\n|%)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -262,7 +262,7 @@
 				</dict>
 			</array>
 			<key>end</key>
-			<string>(?=;|(?&lt;!(?:\.\.\..*))\n|%)</string>
+			<string>(?=;|(?&lt;!(?:\.{3}.*))\n|%)</string>
 		</dict>
 		<key>blocks</key>
 		<dict>
@@ -299,7 +299,7 @@
 							<key>begin</key>
 							<string>\G(?!$)</string>
 							<key>end</key>
-							<string>(?&lt;!\.\.\.)(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -355,7 +355,7 @@
 							<key>begin</key>
 							<string>\G(?!$)</string>
 							<key>end</key>
-							<string>(?&lt;!\.\.\.)(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -385,7 +385,7 @@
 									<key>begin</key>
 									<string>\G(?!$)</string>
 									<key>end</key>
-									<string>(?&lt;!\.\.\.)(?:(?=([,;])(?![^(]*\)))|$)</string>
+									<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
 									<key>patterns</key>
 									<array>
 										<dict>
@@ -449,7 +449,7 @@
 							<key>begin</key>
 							<string>\G(?!$)</string>
 							<key>end</key>
-							<string>(?&lt;!\.\.\.)(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -495,7 +495,7 @@
 							<key>begin</key>
 							<string>\G(?!$)</string>
 							<key>end</key>
-							<string>(?&lt;!\.\.\.)(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -544,7 +544,7 @@
 							<key>name</key>
 							<string>meta.case.matlab</string>
 							<key>match</key>
-							<string>(\s*)(?&lt;=^|[\s,;])(case)\b(.*?)(?&lt;!\.\.\.)(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(\s*)(?&lt;=^|[\s,;])(case)\b(.*?)(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>captures</key>
 							<dict>
 								<key>2</key>
@@ -559,7 +559,7 @@
 									<key>begin</key>
 									<string>\G(?!$)</string>
 									<key>end</key>
-									<string>(?&lt;!\.\.\.)(?:(?=([,;])(?![^(]*\)))|$)</string>
+									<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
 									<key>patterns</key>
 									<array>
 										<dict>
@@ -681,7 +681,7 @@
 							<key>begin</key>
 							<string>\G</string>
 							<key>end</key>
-							<string>(?&lt;!\.\.\.)(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>endCaptures</key>
 							<dict>
 								<key>1</key>
@@ -740,7 +740,7 @@
 							<key>begin</key>
 							<string>\G</string>
 							<key>end</key>
-							<string>(?&lt;!\.\.\.)(?=\n)</string>
+							<string>(?&lt;!\.{3})(?=\n)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -832,7 +832,7 @@
 												</dict>
 											</dict>
 											<key>end</key>
-											<string>(?&lt;!\.\.\.)(?=\n)</string>
+											<string>(?&lt;!\.{3})(?=\n)</string>
 											<key>patterns</key>
 											<array>
 												<dict>
@@ -902,7 +902,7 @@
 										</dict>
 									</array>
 									<key>end</key>
-									<string>(?&lt;!\.\.\.)(?=\s*%|\n)</string>
+									<string>(?&lt;!\.{3})(?=\s*%|\n)</string>
 								</dict>
 							</array>
 						</dict>
@@ -1251,7 +1251,7 @@
 			<key>comment</key>
 			<string>					  1 				   2		3 				   4																															   </string>
 			<key>match</key>
-			<string>(?&lt;=^|[^.]\n|;|,|=)([^\S\n]*)(?# A&gt; )(\b\w+\b)([^\S\n]+)(?# B&gt; )((?!(\+|-|\*|\.\*|\/|\.\/|\\|\.\\|\^|\.\^|==|~=|&amp;|&amp;&amp;|\||\|\||=|:|&gt;|&gt;=|&lt;|&lt;=|\.\.\.)[^\S\n]?)[^\s({=;%][^\n;%]*)</string>
+			<string>(?&lt;=^|[^.]\n|;|,|=)([^\S\n]*)(?# A&gt; )(\b\w+\b)([^\S\n]+)(?# B&gt; )((?!(\+|-|\*|\.\*|\/|\.\/|\\|\.\\|\^|\.\^|==|~=|&amp;|&amp;&amp;|\||\|\||=|:|&gt;|&gt;=|&lt;|&lt;=|\.{3})[^\S\n]?)[^\s({=;%][^\n;%]*)</string>
 		</dict>
 		<key>comment_block</key>
 		<dict>
@@ -1454,7 +1454,7 @@
 							<key>begin</key>
 							<string>\G</string>
 							<key>end</key>
-							<string>(?&lt;=\))|(?&gt;(?&lt;!\.\.\..*)\n)</string>
+							<string>(?&lt;=\))|(?&gt;(?&lt;!\.{3}.*)\n)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -1699,7 +1699,7 @@
 			<key>begin</key>
 			<string>([a-zA-Z][a-zA-Z0-9_]*)\s*(\()</string>
 			<key>end</key>
-			<string>(\)|(?&lt;!\.\.\..*)\n)</string>
+			<string>(\)|(?&lt;!\.{3}.*)\n)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -1811,7 +1811,7 @@
 			<key>begin</key>
 			<string>([a-zA-Z][a-zA-Z0-9_]*)\s*(\.)(\()</string>
 			<key>end</key>
-			<string>(\)|(?&lt;!\.\.\..*)\n)</string>
+			<string>(\)|(?&lt;!\.{3}.*)\n)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -1911,7 +1911,7 @@
 			<key>begin</key>
 			<string>\(</string>
 			<key>end</key>
-			<string>(\)|(?&lt;!\.\.\..*)\n)</string>
+			<string>(\)|(?&lt;!\.{3}.*)\n)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -2082,7 +2082,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(\}|(?&lt;!\.\.\..*)\n)</string>
+			<string>(\}|(?&lt;!\.{3}.*)\n)</string>
 			<key>comment</key>
 			<string>We don't include $self here to avoid matching command syntax inside (), [], {}</string>
 			<key>patterns</key>
@@ -2121,7 +2121,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\.\.\.)(.*)$</string>
+			<string>(\.{3})(.*)$</string>
 		</dict>
 		<key>shell_string</key>
 		<dict>
@@ -2277,7 +2277,7 @@
 			<key>begin</key>
 			<string>([a-zA-Z][a-zA-Z0-9_]*)(@)\s*([a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)*)(\()</string>
 			<key>end</key>
-			<string>(\)|(?&lt;!\.\.\..*)\n)</string>
+			<string>(\)|(?&lt;!\.{3}.*)\n)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -2512,7 +2512,7 @@
 					<key>name</key>
 					<string>keyword.operator.arithmetic.matlab</string>
 					<key>match</key>
-					<string>(?&lt;=[a-zA-Z0-9\s])(\+|-|\*|\.\*|/|\./|\\|\.\\|\^|\.\^)(?=[a-zA-Z0-9\s]|(?:\.\.\.))</string>
+					<string>(?&lt;=[a-zA-Z0-9\s])(\+|-|\*|\.\*|/|\./|\\|\.\\|\^|\.\^)(?=[a-zA-Z0-9\s]|(?:\.{3}))</string>
 				</dict>
 				<dict>
 					<key>comment</key>
@@ -2520,7 +2520,7 @@
 					<key>name</key>
 					<string>keyword.operator.logical.matlab</string>
 					<key>match</key>
-					<string>(?&lt;=[a-zA-Z0-9\s])(==|~=|&amp;|&amp;&amp;|\||\|\|)(?=[a-zA-Z0-9\s]|(?:\.\.\.))</string>
+					<string>(?&lt;=[a-zA-Z0-9\s])(==|~=|&amp;|&amp;&amp;|\||\|\|)(?=[a-zA-Z0-9\s]|(?:\.{3}))</string>
 				</dict>
 				<dict>
 					<key>comment</key>
@@ -2536,7 +2536,7 @@
 					<key>name</key>
 					<string>keyword.operator.vector.colon.matlab</string>
 					<key>match</key>
-					<string>(?&lt;=[a-zA-Z0-9_\s(){,]|^):(?=[a-zA-Z0-9_\s()},]|$||(?:\.\.\.))</string>
+					<string>(?&lt;=[a-zA-Z0-9_\s(){,]|^):(?=[a-zA-Z0-9_\s()},]|$||(?:\.{3}))</string>
 				</dict>
 				<dict>
 					<key>comment</key>
@@ -2544,7 +2544,7 @@
 					<key>name</key>
 					<string>keyword.operator.relational.matlab</string>
 					<key>match</key>
-					<string>(?&lt;=[a-zA-Z0-9\s])(&gt;|&gt;=|&lt;|&lt;=)(?=[a-zA-Z0-9\s]|(?:\.\.\.))</string>
+					<string>(?&lt;=[a-zA-Z0-9\s])(&gt;|&gt;=|&lt;|&lt;=)(?=[a-zA-Z0-9\s]|(?:\.{3}))</string>
 				</dict>
 			</array>
 		</dict>

--- a/test/t41FunctionDefinitions.m
+++ b/test/t41FunctionDefinitions.m
@@ -1,63 +1,146 @@
 % SYNTAX TEST "source.matlab"  "Function declarations: https://github.com/mathworks/MATLAB-Language-grammar/issues/41"
-function tFunctionDefinitions()
-%        ^^^^^^^^^^^^^^^^^^^^entity.name.function.matlab
+function tFunctionDefinitions(in1)
+%        ^^^^^^^^^^^^^^^^^^^^ entity.name.function.matlab
     % Help text
-    y = "a string";
-    %<- variable.other.readwrite.matlab
+    y = in1;
     %   ^^^^^^^^^^string.quoted.double.matlab
     anonymousFunction = @(in1,in2) in1 + in2;
-    %                 ^keyword.operator.assignment.matlab
-    %                   ^punctuation.definition.function.anonymous.matlab
-    %                    ^punctuation.definition.parameters.begin.matlab
-    %                     ^^^variable.parameter.input.matlab
-    %                        ^punctuation.separator.parameter.comma.matlab
-    %                         ^^^variable.parameter.input.matlab
-    %                            ^punctuation.definition.parameters.end.matlab
-    %                                  ^keyword.operator.arithmetic.matlab
-    %                                       ^punctuation.terminator.semicolon.matlab
+    %                 ^ keyword.operator.assignment.matlab
+    %                   ^ punctuation.definition.function.anonymous.matlab
+    %                    ^ punctuation.definition.parameters.begin.matlab
+    %                     ^^^ variable.parameter.input.matlab
+    %                        ^ punctuation.separator.parameter.comma.matlab
+    %                         ^^^ variable.parameter.input.matlab
+    %                            ^ punctuation.definition.parameters.end.matlab
+    %                                  ^ keyword.operator.arithmetic.matlab
+    %                                       ^ punctuation.terminator.semicolon.matlab
 
 end
 %<- storage.type.function.end.matlab
 
 function [a,b,c] = multiOutput()
-%                  ^^^^^^^^^^^entity.name.function.matlab
+%        ^ punctuation.section.assignment.group.begin.matlab
+%         ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%          ^ meta.assignment.variable.output.matlab punctuation.separator.parameter.comma.matlab
+%           ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%            ^ meta.assignment.variable.output.matlab punctuation.separator.parameter.comma.matlab
+%             ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%              ^ punctuation.section.assignment.group.end.matlab
+%                ^ keyword.operator.assignment.matlab
+%                  ^^^^^^^^^^^ entity.name.function.matlab
+%                             ^ meta.parameters.matlab punctuation.definition.parameters.begin.matlab
+%                              ^ meta.parameters.matlab punctuation.definition.parameters.end.matlab
     % Help text
-    y = "a string";
-%       ^^^^^^^^^^string.quoted.double.matlab
+    a = "a string";
+    b = "b string";
+    c = "c string";
 end
 %<- storage.type.function.end.matlab
 
-function [a,b,...
+function [a,b,... comment
+%        ^ punctuation.section.assignment.group.begin.matlab
+%         ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%          ^ meta.assignment.variable.output.matlab punctuation.separator.parameter.comma.matlab
+%           ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%            ^ meta.assignment.variable.output.matlab punctuation.separator.parameter.comma.matlab
+%             ^^^ meta.assignment.variable.output.matlab punctuation.separator.continuation.line.matlab
+%                 ^^^^^^^ meta.assignment.variable.output.matlab comment.continuation.line.matlab
     c] = multiLine(in1)
-%        ^^^^^^^^^entity.name.function.matlab
+%   ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%    ^ punctuation.section.assignment.group.end.matlab
+%      ^ keyword.operator.assignment.matlab
+%        ^^^^^^^^^ entity.name.function.matlab
+%                 ^ meta.parameters.matlab punctuation.definition.parameters.begin.matlab
+%                  ^^^ meta.parameters.matlab variable.parameter.input.matlab
+%                     ^ meta.parameters.matlab punctuation.definition.parameters.end.matlab
     % Help text
-    y = "a string";
-%       ^^^^^^^^^^string.quoted.double.matlab
+    a = in1;
+    b = "a string";
 end
 %<- storage.type.function.end.matlab
 
-function [a,b,...
-    c] = multiLine2(in1,...
-    in2)%^^^^^^^^^^entity.name.function.matlab
-
+function [a,...
+%        ^ punctuation.section.assignment.group.begin.matlab
+%         ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%          ^ meta.assignment.variable.output.matlab punctuation.separator.parameter.comma.matlab
+%           ^^^ meta.assignment.variable.output.matlab punctuation.separator.continuation.line.matlab
+    b] = multiLine2 (in1,... comment
+%   ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%    ^ punctuation.section.assignment.group.end.matlab
+%      ^ keyword.operator.assignment.matlab
+%        ^^^^^^^^^^ entity.name.function.matlab
+%                   ^ meta.parameters.matlab punctuation.definition.parameters.begin.matlab
+%                    ^^^ meta.parameters.matlab variable.parameter.input.matlab
+%                       ^ meta.parameters.matlab punctuation.separator.parameter.comma.matlab
+%                        ^^^ meta.parameters.matlab punctuation.separator.continuation.line.matlab
+%                            ^^^^^^^ meta.parameters.matlab comment.continuation.line.matlab
+    in2)
+%   ^^^ meta.parameters.matlab variable.parameter.input.matlab
+%      ^ meta.parameters.matlab punctuation.definition.parameters.end.matlab
     % Help text
-    y = "a string";
-%       ^^^^^^^^^^string.quoted.double.matlab
+    a = in1;
+    b = in2;
 end
 %<- storage.type.function.end.matlab
+
+
+function a ... comment
+%        ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%          ^^^ meta.assignment.variable.output.matlab punctuation.separator.continuation.line.matlab
+%              ^^^^^^^ meta.assignment.variable.output.matlab comment.continuation.line.matlab
+    = multiline3...
+%   ^ keyword.operator.assignment.matlab
+%     ^^^^^^^^^^ entity.name.function.matlab 
+%               ^^^ meta.function.declaration.matlab punctuation.separator.continuation.line.matlab
+    (in1)
+%   ^ meta.parameters.matlab punctuation.definition.parameters.begin.matlab
+%    ^^^ meta.parameters.matlab variable.parameter.input.matlab
+%       ^ meta.parameters.matlab punctuation.definition.parameters.end.matlab
+    a = in1;
+end
+
+
+function multiline4(... comment
+%        ^^^^^^^^^^ entity.name.function.matlab 
+%                  ^ meta.parameters.matlab punctuation.definition.parameters.begin.matlab
+%                   ^^^ meta.parameters.matlab punctuation.separator.continuation.line.matlab
+%                       ^^^^^^^ meta.parameters.matlab comment.continuation.line.matlab
+    in1)
+%   ^^^ meta.parameters.matlab variable.parameter.input.matlab
+%      ^ meta.parameters.matlab punctuation.definition.parameters.end.matlab
+    disp(in1);
+end
+
+function    [...
+%           ^ punctuation.section.assignment.group.begin.matlab
+%            ^^^ meta.assignment.variable.output.matlab punctuation.separator.continuation.line.matlab
+    a...
+%   ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%    ^^^ meta.assignment.variable.output.matlab punctuation.separator.continuation.line.matlab
+        ,b] ... comment
+%       ^ meta.assignment.variable.output.matlab punctuation.separator.parameter.comma.matlab
+%        ^ meta.assignment.variable.output.matlab variable.parameter.output.matlab
+%         ^ punctuation.section.assignment.group.end.matlab
+%           ^^^ meta.function.declaration.matlab punctuation.separator.continuation.line.matlab
+%               ^^^^^^^ meta.function.declaration.matlab comment.continuation.line.matlab
+    = multiline5(in1)
+%   ^ keyword.operator.assignment.matlab
+%     ^^^^^^^^^^ entity.name.function.matlab
+%               ^ meta.parameters.matlab punctuation.definition.parameters.begin.matlab
+%                ^^^ meta.parameters.matlab variable.parameter.input.matlab
+%                   ^ meta.parameters.matlab punctuation.definition.parameters.end.matlab
+    a = in1;
+    b = "a string";
+end
 
 function functionWithoutParens
-%        ^^^^^^^^^^^^^^^^^^^^^meta.function.matlab
-%        ^^^^^^^^^^^^^^^^^^^^^entity.name.function.matlab
+%        ^^^^^^^^^^^^^^^^^^^^^meta.function.matlab entity.name.function.matlab
     % Help text
     y = "a string";
-%       ^^^^^^^^^^string.quoted.double.matlab
 end
 %<- storage.type.function.end.matlab
 
 function functionWithoutParensAndEnd
-    %        ^^^^^^^^^^^^^^^^^^^^^meta.function.matlab
-    %        ^^^^^^^^^^^^^^^^^^^^^entity.name.function.matlab
+%        ^^^^^^^^^^^^^^^^^^^^^^^^^^^meta.function.matlab entity.name.function.matlab
         % Help text
         y = "a string";
-    %       ^^^^^^^^^^string.quoted.double.matlab


### PR DESCRIPTION
This PR fixes #72, when function definitions are declared on multiple lines. 

I will add comments in every change of the tmLanguage describing why is is required. 

The PR adds scope checks and additional cases to the existing test *test/t41FunctionDefinitions.m*

## Limitation
Due to the nature of the per-line matching behavior of the textmate language grammar, and the almost unrestricted usage of MATLAB's line continuation operator `...`, it is impossible to differentiate between:

1. Function with no output argument and input argument declaration including parenthesis on new line: 
  ```matlab
  function funcNoOutputParensOnNewLine ...
      (inputArg)
      disp(inputArg);
  end
  ```

2. Function with a single output argument without brackets and equals sign on new line:
  ```matlab
  function outputArg ... 
      = funcSingleOutputEqualSignOnNewLine (inputArg)
      outputArg = inputArg;
  end
  ```

Here, a choice needs to be made to favor one over the other. The current PR favors option 2, for no other reason than that it looks less weird to me than option 1. If option 2 is chosen, the input argument of the example of option 1 will be tokenized as:
``` matlab
(inputArg)
%< punctuation.section.parens.begin.matlab
%^^^^^^^^ meta.parens.matlab variable.other.readwrite.matlab
%        ^ punctuation.section.parens.end.matlab
```
The added testcase covers option 2. 
https://github.com/watermarkhu/MATLAB-Language-grammar/blob/f69e90b0d935ad1f39caf6728b6561544af0efa9/test/t41FunctionDefinitions.m#L87-L91
