### PR TITLE
Fix elseif and else meta blocks

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -299,7 +299,7 @@
 							<key>begin</key>
 							<string>\G(?!$)</string>
 							<key>end</key>
-							<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(?&lt;!\.{3}.*)(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -355,7 +355,7 @@
 							<key>begin</key>
 							<string>\G(?!$)</string>
 							<key>end</key>
-							<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(?&lt;!\.{3}.*)(?:(?=[,;](?![^(]*\)))|$)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -367,9 +367,9 @@
 						<dict>
 							<key>name</key>
 							<string>meta.elseif.matlab</string>
-							<key>match</key>
-							<string>(?:\s*)(?&lt;=^|[\s,;])(elseif)\b</string>
-							<key>captures</key>
+							<key>begin</key>
+							<string>\s*(?&lt;=^|[\s,;])(elseif)\b</string>
+							<key>beginCaptures</key>
 							<dict>
 								<key>1</key>
 								<dict>
@@ -377,6 +377,8 @@
 									<string>keyword.control.elseif.matlab</string>
 								</dict>
 							</dict>
+							<key>end</key>
+							<string>\s*(?&lt;=^|[\s,;])(?=elseif|else|end)\b</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -385,7 +387,7 @@
 									<key>begin</key>
 									<string>\G(?!$)</string>
 									<key>end</key>
-									<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
+									<string>(?&lt;!\.{3}.*)(?:(?=([,;])(?![^(]*\)))|$)</string>
 									<key>patterns</key>
 									<array>
 										<dict>
@@ -394,14 +396,18 @@
 										</dict>
 									</array>
 								</dict>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
 							</array>
 						</dict>
 						<dict>
 							<key>name</key>
 							<string>meta.else.matlab</string>
-							<key>match</key>
-							<string>(?:\s*)(?&lt;=^|[\s,;])(else)\b</string>
-							<key>captures</key>
+							<key>begin</key>
+							<string>\s*(?&lt;=^|[\s,;])(else)\b</string>
+							<key>beginCaptures</key>
 							<dict>
 								<key>1</key>
 								<dict>
@@ -410,7 +416,14 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>^</string>
+							<string>\s*(?&lt;=^|[\s,;])(?=end)\b</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
 						</dict>
 						<dict>
 							<key>include</key>
@@ -449,7 +462,7 @@
 							<key>begin</key>
 							<string>\G(?!$)</string>
 							<key>end</key>
-							<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(?&lt;!\.{3}.*)(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -495,7 +508,7 @@
 							<key>begin</key>
 							<string>\G(?!$)</string>
 							<key>end</key>
-							<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(?&lt;!\.{3}.*)(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -544,7 +557,7 @@
 							<key>name</key>
 							<string>meta.case.matlab</string>
 							<key>match</key>
-							<string>(\s*)(?&lt;=^|[\s,;])(case)\b(.*?)(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(\s*)(?&lt;=^|[\s,;])(case)\b(.*?)(?&lt;!\.{3}.*)(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>captures</key>
 							<dict>
 								<key>2</key>
@@ -559,7 +572,7 @@
 									<key>begin</key>
 									<string>\G(?!$)</string>
 									<key>end</key>
-									<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
+									<string>(?&lt;!\.{3}.*)(?:(?=([,;])(?![^(]*\)))|$)</string>
 									<key>patterns</key>
 									<array>
 										<dict>
@@ -681,7 +694,7 @@
 							<key>begin</key>
 							<string>\G</string>
 							<key>end</key>
-							<string>(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
+							<string>(?&lt;!\.{3}.*)(?:(?=([,;])(?![^(]*\)))|$)</string>
 							<key>endCaptures</key>
 							<dict>
 								<key>1</key>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -692,17 +692,16 @@
 							<key>name</key>
 							<string>meta.while.declaration.matlab</string>
 							<key>begin</key>
-							<string>\G</string>
+							<string>\G(?!$)</string>
 							<key>end</key>
-							<string>(?&lt;!\.{3}.*)(?:(?=([,;])(?![^(]*\)))|$)</string>
-							<key>endCaptures</key>
-							<dict>
-								<key>1</key>
+							<string>(?&lt;!\.{3}.*)(?:(?=[,;](?![^(]*\)))|$)</string>
+							<key>patterns</key>
+							<array>
 								<dict>
 									<key>include</key>
 									<string>$self</string>
 								</dict>
-							</dict>
+							</array>
 						</dict>
 						<dict>
 							<key>include</key>

--- a/test/snap/Account.m.snap
+++ b/test/snap/Account.m.snap
@@ -108,15 +108,15 @@
 #^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.else.matlab
 #                ^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.else.matlab keyword.control.else.matlab
 >                    error('Value must be numeric')
-#^^^^^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab
-#                    ^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.function-call.parens.matlab entity.name.function.matlab
-#                         ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.function-call.parens.matlab punctuation.section.parens.begin.matlab
-#                          ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.function-call.parens.matlab string.quoted.single.matlab punctuation.definition.string.begin.matlab
-#                           ^^^^^^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.function-call.parens.matlab string.quoted.single.matlab
-#                                                ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.function-call.parens.matlab string.quoted.single.matlab punctuation.definition.string.end.matlab
-#                                                 ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.function-call.parens.matlab punctuation.section.parens.end.matlab
+#^^^^^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.else.matlab
+#                    ^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab entity.name.function.matlab
+#                         ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab punctuation.section.parens.begin.matlab
+#                          ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab string.quoted.single.matlab punctuation.definition.string.begin.matlab
+#                           ^^^^^^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab string.quoted.single.matlab
+#                                                ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab string.quoted.single.matlab punctuation.definition.string.end.matlab
+#                                                 ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab punctuation.section.parens.end.matlab
 >                end
-#^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab
+#^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab meta.else.matlab
 #                ^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab meta.if.matlab keyword.control.end.if.matlab
 >            end
 #^^^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.if.matlab

--- a/test/snap/Account.m.snap
+++ b/test/snap/Account.m.snap
@@ -278,7 +278,10 @@
 #            ^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.while.matlab keyword.control.while.matlab
 #                 ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.while.matlab meta.while.declaration.matlab
 #                  ^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.while.matlab meta.while.declaration.matlab variable.other.readwrite.matlab
-#                            ^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.while.matlab meta.while.declaration.matlab
+#                            ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.while.matlab meta.while.declaration.matlab
+#                             ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.while.matlab meta.while.declaration.matlab keyword.operator.relational.matlab
+#                              ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.while.matlab meta.while.declaration.matlab
+#                               ^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.while.matlab meta.while.declaration.matlab constant.numeric.decimal.matlab
 >                n = n + 1;
 #^^^^^^^^^^^^^^^^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.while.matlab
 #                ^ source.matlab meta.class.matlab meta.methods.matlab meta.function.matlab meta.while.matlab meta.assignment.variable.single.matlab variable.other.readwrite.matlab

--- a/test/snap/controlFlow.m.snap
+++ b/test/snap/controlFlow.m.snap
@@ -119,35 +119,35 @@
 >    elseif y < 20
 #^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab
 #    ^^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab keyword.control.elseif.matlab
-#          ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab
-#           ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab variable.other.readwrite.matlab
-#            ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab
-#             ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab keyword.operator.relational.matlab
-#              ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab
-#               ^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab constant.numeric.decimal.matlab
+#          ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab
+#           ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab variable.other.readwrite.matlab 
+#            ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab
+#             ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab keyword.operator.relational.matlab
+#              ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab
+#               ^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab constant.numeric.decimal.matlab
 >        disp('y < 20');
-#^^^^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab
-#        ^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab entity.name.function.matlab
-#            ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab punctuation.section.parens.begin.matlab
-#             ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab string.quoted.single.matlab punctuation.definition.string.begin.matlab
-#              ^^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab string.quoted.single.matlab
-#                    ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab string.quoted.single.matlab punctuation.definition.string.end.matlab
-#                     ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab punctuation.section.parens.end.matlab
-#                      ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab punctuation.terminator.semicolon.matlab
+#^^^^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab
+#        ^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.function-call.parens.matlab entity.name.function.matlab
+#            ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.function-call.parens.matlab punctuation.section.parens.begin.matlab
+#             ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.function-call.parens.matlab string.quoted.single.matlab punctuation.definition.string.begin.matlab
+#              ^^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.function-call.parens.matlab string.quoted.single.matlab
+#                    ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.function-call.parens.matlab string.quoted.single.matlab punctuation.definition.string.end.matlab
+#                     ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.function-call.parens.matlab punctuation.section.parens.end.matlab
+#                      ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab punctuation.terminator.semicolon.matlab
 >    else
-#^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab
+#^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab
 #    ^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab keyword.control.else.matlab
 >        disp("y >= 20");
-#^^^^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab
-#        ^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab entity.name.function.matlab
-#            ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab punctuation.section.parens.begin.matlab
-#             ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab string.quoted.double.matlab punctuation.definition.string.begin.matlab
-#              ^^^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab string.quoted.double.matlab
-#                     ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab string.quoted.double.matlab punctuation.definition.string.end.matlab
-#                      ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.function-call.parens.matlab punctuation.section.parens.end.matlab
-#                       ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab punctuation.terminator.semicolon.matlab
+#^^^^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab
+#        ^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab entity.name.function.matlab
+#            ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab punctuation.section.parens.begin.matlab
+#             ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab string.quoted.double.matlab punctuation.definition.string.begin.matlab
+#              ^^^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab string.quoted.double.matlab
+#                     ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab string.quoted.double.matlab punctuation.definition.string.end.matlab
+#                      ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab punctuation.section.parens.end.matlab
+#                       ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab punctuation.terminator.semicolon.matlab
 >    end
-#^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab
+#^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab 
 #    ^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab keyword.control.end.if.matlab
 >catch ME
 #^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.catch.matlab keyword.control.catch.matlab

--- a/test/t78EOLcommentsInBlocks.m
+++ b/test/t78EOLcommentsInBlocks.m
@@ -1,0 +1,37 @@
+% SYNTAX TEST "source.matlab"  "EOLcommentsInBlocks: https://github.com/mathworks/MATLAB-Language-grammar/pull/78"
+
+
+while test % test
+% <---- keyword.control.while.matlab
+%     ^^^^ meta.while.declaration.matlab
+%          ^^^^^^ comment.line.percentage.matlab
+    % test
+end
+
+while (test) % test
+% <---- keyword.control.while.matlab
+%     ^^^^^^ meta.while.declaration.matlab
+%            ^^^^^^ comment.line.percentage.matlab
+    % test
+end
+
+while test; % test
+% <---- keyword.control.while.matlab
+%     ^^^^ meta.while.declaration.matlab
+%           ^^^^^^ comment.line.percentage.matlab
+    % test
+end
+
+for i = 1:10 % test
+% <-- keyword.control.for.matlab
+%     ^^^^^ meta.for.declaration.matlab
+%            ^^^^^^ comment.line.percentage.matlab
+    % test
+end
+
+if i == 10 % test
+% <-- keyword.control.if.matlab
+%  ^^^^^^^ meta.if.declaration.matlab
+%          ^^^^^^ comment.line.percentage.matlab
+    % test
+end


### PR DESCRIPTION
The `meta.elseif.matlab` and `meta.else.matlab` scopes only detected for the `elseif` and `else` keywords. This is due to both scopes using the *match* rule, while it should be using *begin/end* instead. The patterns in the match rule are never used as a *match* rule does not support patterns. 

Also fixes #78 and while declarations are recognized. 

Additionally, better support for line continuations including comments in multiline declarations. 