### PR TITLE
Anonymous functions as arguments

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -227,7 +227,7 @@
 					<key>begin</key>
 					<string>(?&lt;=\))[^\S\n]*(\()?</string>
 					<key>end</key>
-					<string>(\))?[^\S\n]*(?=;|(?&lt;!(?:\.{3}.*))\n|%)</string>
+					<string>(\))?[^\S\n]*(?=;|,|(?&lt;!(?:\.{3}.*))\n|%)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -262,7 +262,7 @@
 				</dict>
 			</array>
 			<key>end</key>
-			<string>(?=;|(?&lt;!(?:\.{3}.*))\n|%)</string>
+			<string>(?=;|,|(?&lt;!(?:\.{3}.*))\n|%)</string>
 		</dict>
 		<key>blocks</key>
 		<dict>

--- a/test/t54LineContinuationInAnonymousFunctions.m
+++ b/test/t54LineContinuationInAnonymousFunctions.m
@@ -1,4 +1,4 @@
-% SYNTAX TEST "source.matlab"  "LineContinationInAnonymousFunctions: https://github.com/mathworks/MATLAB-Language-grammar/pull/52"
+% SYNTAX TEST "source.matlab"  "LineContinationInAnonymousFunctions: https://github.com/mathworks/MATLAB-Language-grammar/pull/54"
 
 
 @(x, y) x.^2+y;

--- a/test/t54LineContinuationInAnonymousFunctions.m
+++ b/test/t54LineContinuationInAnonymousFunctions.m
@@ -1,4 +1,4 @@
-% SYNTAX TEST "source.matlab"  "Imports: https://github.com/mathworks/MATLAB-Language-grammar/pull/52"
+% SYNTAX TEST "source.matlab"  "LineContinationInAnonymousFunctions: https://github.com/mathworks/MATLAB-Language-grammar/pull/52"
 
 
 @(x, y) x.^2+y;

--- a/test/t57Operators.m
+++ b/test/t57Operators.m
@@ -1,4 +1,4 @@
-% SYNTAX TEST "source.matlab"  "Imports: https://github.com/mathworks/MATLAB-Language-grammar/pull/57"
+% SYNTAX TEST "source.matlab"  "Operators: https://github.com/mathworks/MATLAB-Language-grammar/pull/57"
 
 %% Assignment and metadata query
 

--- a/test/t61ReadWriteOperations.m
+++ b/test/t61ReadWriteOperations.m
@@ -1,4 +1,4 @@
-% SYNTAX TEST "source.matlab"  "Imports: https://github.com/mathworks/MATLAB-Language-grammar/pull/51"
+% SYNTAX TEST "source.matlab"  "ReadWriteOperations: https://github.com/mathworks/MATLAB-Language-grammar/pull/51"
 
 variable
 % <------- variable.other.readwrite.matlab

--- a/test/t61ReadWriteOperations.m
+++ b/test/t61ReadWriteOperations.m
@@ -1,4 +1,4 @@
-% SYNTAX TEST "source.matlab"  "ReadWriteOperations: https://github.com/mathworks/MATLAB-Language-grammar/pull/51"
+% SYNTAX TEST "source.matlab"  "ReadWriteOperations: https://github.com/mathworks/MATLAB-Language-grammar/pull/61"
 
 variable
 % <------- variable.other.readwrite.matlab

--- a/test/t80AnonymousFunctionArgument.m
+++ b/test/t80AnonymousFunctionArgument.m
@@ -1,4 +1,4 @@
-% SYNTAX TEST "source.matlab"  "AnonymousFunctionArgument: https://github.com/mathworks/MATLAB-Language-grammar/pull/51"
+% SYNTAX TEST "source.matlab"  "AnonymousFunctionArgument: https://github.com/mathworks/MATLAB-Language-grammar/pull/80"
 
 q = integral(@(x) x.^2, 0, 1);
 %            ^^^^^^^^^ meta.function.anonymous.matlab

--- a/test/t80AnonymousFunctionArgument.m
+++ b/test/t80AnonymousFunctionArgument.m
@@ -1,0 +1,23 @@
+% SYNTAX TEST "source.matlab"  "AnonymousFunctionArgument: https://github.com/mathworks/MATLAB-Language-grammar/pull/51"
+
+q = integral(@(x) x.^2, 0, 1);
+%            ^^^^^^^^^ meta.function.anonymous.matlab
+%                     ^ - meta.function.anonymous.matlab
+
+
+if ~isempty(lstr)
+    p.DataTipTemplate.DataTipRows(end+1) = ...
+        dataTipTextRow('cBin', arrayfun(@(x) lstr, binsX, 'UniformOutput', false));
+%                                       ^^^^^^^^^ meta.function.anonymous.matlab
+%                                                ^ - meta.function.anonymous.matlab 
+end
+% <-- meta.if.matlab keyword.control.end.if.matlab
+
+    
+if ~isempty(lstr)
+    p.DataTipTemplate.DataTipRows(end+1) = ...
+        dataTipTextRow('cBin', arrayfun(@(x) lstr, binsX, 'UniformOutput', false));
+%                                       ^^^^^^^^^ meta.function.anonymous.matlab
+%                                                ^ - meta.function.anonymous.matlab 
+end
+% <-- meta.if.matlab keyword.control.end.if.matlab


### PR DESCRIPTION
Fixes #80 

Anonymous functions are currently defined to end on `;` or comment. This does now allow for declaring anonymous function directly as argument to a function. 