### PR TITLE
fix switch statements

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -514,7 +514,7 @@
 					<key>name</key>
 					<string>meta.switch.matlab</string>
 					<key>begin</key>
-					<string>\s*(?&lt;=^|[\s,;])(switch)\s+([a-zA-Z0-9][a-zA-Z0-9_]*)</string>
+					<string>\s*(?&lt;=^|[\s,;])(switch)\b</string>
 					<key>end</key>
 					<string>\s*(?&lt;=^|[\s,;])(end)\b</string>
 					<key>beginCaptures</key>
@@ -524,11 +524,6 @@
 							<key>name</key>
 							<string>keyword.control.switch.matlab</string>
 						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.constant.matlab</string>
-						</dict>
 					</dict>
 					<key>endCaptures</key>
 					<dict>
@@ -537,22 +532,51 @@
 							<key>name</key>
 							<string>keyword.control.end.switch.matlab</string>
 						</dict>
+						<key>2</key>
+						<dict>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
+						</dict>
 					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>
 							<key>name</key>
+							<string>meta.switch.declaration.matlab</string>
+							<key>begin</key>
+							<string>\G(?!$)</string>
+							<key>end</key>
+							<string>(?&lt;!\.{3}.*)(?:(?=[,;](?![^(]*\)))|$)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>name</key>
 							<string>meta.case.matlab</string>
-							<key>match</key>
-							<string>(\s*)(?&lt;=^|[\s,;])(case)\b(.*?)(?&lt;!\.{3})(?:(?=([,;])(?![^(]*\)))|$)</string>
-							<key>captures</key>
+							<key>begin</key>
+							<string>\s*(?&lt;=^|[\s,;])(case)\b</string>
+							<key>beginCaptures</key>
 							<dict>
-								<key>2</key>
+								<key>1</key>
 								<dict>
 									<key>name</key>
 									<string>keyword.control.switch.case.matlab</string>
 								</dict>
-								<key>3</key>
+							</dict>
+							<key>end</key>
+							<string>\s*(?&lt;=^|[\s,;])(?=case|otherwise|end)\b</string>
+							<key>patterns</key>
+							<array>
 								<dict>
 									<key>name</key>
 									<string>meta.case.declaration.matlab</string>
@@ -568,31 +592,34 @@
 										</dict>
 									</array>
 								</dict>
-							</dict>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
 						</dict>
 						<dict>
 							<key>name</key>
 							<string>meta.otherwise.matlab</string>
-							<key>match</key>
-							<string>(\s*)(?&lt;=^|[\s,;])(otherwise)\b</string>
-							<key>captures</key>
+							<key>begin</key>
+							<string>\s*(?&lt;=^|[\s,;])(otherwise)\b</string>
+							<key>beginCaptures</key>
 							<dict>
-								<key>2</key>
+								<key>1</key>
 								<dict>
 									<key>name</key>
 									<string>keyword.control.switch.otherwise.matlab</string>
 								</dict>
-								<key>3</key>
-								<dict>
-									<key>patterns</key>
-									<array>
-										<dict>
-											<key>include</key>
-											<string>$self</string>
-										</dict>
-									</array>
-								</dict>
 							</dict>
+							<key>end</key>
+							<string>\s*(?&lt;=^|[\s,;])(?=end)\b</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>$self</string>
+								</dict>
+							</array>
 						</dict>
 						<dict>
 							<key>include</key>

--- a/test/snap/controlFlow.m.snap
+++ b/test/snap/controlFlow.m.snap
@@ -15,79 +15,79 @@
 #   ^^^^^^^^^^^^^^^^^^^^^ source.matlab meta.function.matlab comment.line.double-percentage.matlab entity.name.section.matlab
 >switch nargin
 #^^^^^^ source.matlab meta.function.matlab meta.switch.matlab keyword.control.switch.matlab
-#      ^ source.matlab meta.function.matlab meta.switch.matlab
-#       ^^^^^^ source.matlab meta.function.matlab meta.switch.matlab variable.other.constant.matlab
+#      ^ source.matlab meta.function.matlab meta.switch.matlab meta.switch.declaration.matlab
+#       ^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.switch.declaration.matlab variable.language.function.matlab
 >  case 0
 #^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
 #  ^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab keyword.control.switch.case.matlab
 #      ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.case.declaration.matlab
 #       ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.case.declaration.matlab constant.numeric.decimal.matlab
 >    return
-#^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.control.matlab
-#    ^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.control.matlab keyword.control.flow.matlab
+#^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.control.matlab
+#    ^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.control.matlab keyword.control.flow.matlab
 >  case 1
 #^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
 #  ^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab keyword.control.switch.case.matlab
 #      ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.case.declaration.matlab
 #       ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.case.declaration.matlab constant.numeric.decimal.matlab
 >    y = varargin{1};
-#^^^^ source.matlab meta.function.matlab meta.switch.matlab
-#    ^ source.matlab meta.function.matlab meta.switch.matlab meta.assignment.variable.single.matlab variable.other.readwrite.matlab
-#     ^ source.matlab meta.function.matlab meta.switch.matlab
-#      ^ source.matlab meta.function.matlab meta.switch.matlab keyword.operator.assignment.matlab
-#       ^ source.matlab meta.function.matlab meta.switch.matlab
-#        ^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab variable.language.function.matlab
-#                ^ source.matlab meta.function.matlab meta.switch.matlab
-#                 ^ source.matlab meta.function.matlab meta.switch.matlab constant.numeric.decimal.matlab
-#                  ^ source.matlab meta.function.matlab meta.switch.matlab
-#                   ^ source.matlab meta.function.matlab meta.switch.matlab punctuation.terminator.semicolon.matlab
+#^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#    ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.assignment.variable.single.matlab variable.other.readwrite.matlab
+#     ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#      ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab keyword.operator.assignment.matlab
+#       ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#        ^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab variable.language.function.matlab
+#                ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#                 ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab constant.numeric.decimal.matlab
+#                  ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#                   ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab punctuation.terminator.semicolon.matlab
 >    % Check single-line if inside switch for https://github.com/mathworks/MATLAB-Language-grammar/issues/19
-#^^^^ source.matlab meta.function.matlab meta.switch.matlab punctuation.whitespace.comment.leading.matlab
-#    ^ source.matlab meta.function.matlab meta.switch.matlab comment.line.percentage.matlab punctuation.definition.comment.matlab
-#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab comment.line.percentage.matlab
+#^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab punctuation.whitespace.comment.leading.matlab
+#    ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab comment.line.percentage.matlab punctuation.definition.comment.matlab
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab comment.line.percentage.matlab
 >    if varargin{1} < 0, return; end
-#^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab
-#    ^^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab keyword.control.if.matlab
-#      ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.if.declaration.matlab
-#       ^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.if.declaration.matlab variable.language.function.matlab
-#               ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.if.declaration.matlab
-#                ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.if.declaration.matlab constant.numeric.decimal.matlab
-#                 ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.if.declaration.matlab
-#                  ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.if.declaration.matlab
-#                   ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.if.declaration.matlab keyword.operator.relational.matlab
-#                    ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.if.declaration.matlab
-#                     ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.if.declaration.matlab constant.numeric.decimal.matlab
-#                      ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab punctuation.separator.comma.matlab
-#                       ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.control.matlab
-#                        ^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab meta.control.matlab keyword.control.flow.matlab
-#                              ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab punctuation.terminator.semicolon.matlab
-#                               ^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab
-#                                ^^^ source.matlab meta.function.matlab meta.switch.matlab meta.if.matlab keyword.control.end.if.matlab
+#^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab
+#    ^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab keyword.control.if.matlab
+#      ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.if.declaration.matlab
+#       ^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.if.declaration.matlab variable.language.function.matlab
+#               ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.if.declaration.matlab
+#                ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.if.declaration.matlab constant.numeric.decimal.matlab
+#                 ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.if.declaration.matlab
+#                  ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.if.declaration.matlab
+#                   ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.if.declaration.matlab keyword.operator.relational.matlab
+#                    ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.if.declaration.matlab
+#                     ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.if.declaration.matlab constant.numeric.decimal.matlab
+#                      ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab punctuation.separator.comma.matlab
+#                       ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.control.matlab
+#                        ^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab meta.control.matlab keyword.control.flow.matlab
+#                              ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab punctuation.terminator.semicolon.matlab
+#                               ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab
+#                                ^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.if.matlab keyword.control.end.if.matlab
 >  case 2
 #^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
 #  ^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab keyword.control.switch.case.matlab
 #      ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.case.declaration.matlab
 #       ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.case.declaration.matlab constant.numeric.decimal.matlab
 >    y = varargin{1} + varargin{2};
-#^^^^ source.matlab meta.function.matlab meta.switch.matlab
-#    ^ source.matlab meta.function.matlab meta.switch.matlab meta.assignment.variable.single.matlab variable.other.readwrite.matlab
-#     ^ source.matlab meta.function.matlab meta.switch.matlab
-#      ^ source.matlab meta.function.matlab meta.switch.matlab keyword.operator.assignment.matlab
-#       ^ source.matlab meta.function.matlab meta.switch.matlab
-#        ^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab variable.language.function.matlab
-#                ^ source.matlab meta.function.matlab meta.switch.matlab
-#                 ^ source.matlab meta.function.matlab meta.switch.matlab constant.numeric.decimal.matlab
-#                  ^ source.matlab meta.function.matlab meta.switch.matlab
-#                   ^ source.matlab meta.function.matlab meta.switch.matlab
-#                    ^ source.matlab meta.function.matlab meta.switch.matlab keyword.operator.arithmetic.matlab
-#                     ^ source.matlab meta.function.matlab meta.switch.matlab
-#                      ^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab variable.language.function.matlab
-#                              ^ source.matlab meta.function.matlab meta.switch.matlab
-#                               ^ source.matlab meta.function.matlab meta.switch.matlab constant.numeric.decimal.matlab
-#                                ^ source.matlab meta.function.matlab meta.switch.matlab
-#                                 ^ source.matlab meta.function.matlab meta.switch.matlab punctuation.terminator.semicolon.matlab
+#^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#    ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab meta.assignment.variable.single.matlab variable.other.readwrite.matlab
+#     ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#      ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab keyword.operator.assignment.matlab
+#       ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#        ^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab variable.language.function.matlab
+#                ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#                 ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab constant.numeric.decimal.matlab
+#                  ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#                   ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#                    ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab keyword.operator.arithmetic.matlab
+#                     ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#                      ^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab variable.language.function.matlab
+#                              ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#                               ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab constant.numeric.decimal.matlab
+#                                ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
+#                                 ^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab punctuation.terminator.semicolon.matlab
 >  otherwise
-#^^ source.matlab meta.function.matlab meta.switch.matlab meta.otherwise.matlab
+#^^ source.matlab meta.function.matlab meta.switch.matlab meta.case.matlab
 #  ^^^^^^^^^ source.matlab meta.function.matlab meta.switch.matlab meta.otherwise.matlab keyword.control.switch.otherwise.matlab
 >end
 #^^^ source.matlab meta.function.matlab meta.switch.matlab keyword.control.end.switch.matlab

--- a/test/t19SingleLineBlocks.m
+++ b/test/t19SingleLineBlocks.m
@@ -1,7 +1,7 @@
 % SYNTAX TEST "source.matlab"  "Blocks like if, for, etc. on a single line: https://github.com/mathworks/MATLAB-Language-grammar/issues/19"
 function y = t19SingleLineBlocks(x)
     switch x
-%          ^ variable.other.constant.matlab
+%          ^ meta.switch.declaration.matlab
         case 1
 %       ^^^^ keyword.control.switch.case.matlab
 %            ^ constant.numeric.decimal.matlab
@@ -23,7 +23,7 @@ function y = t19SingleLineBlocks(x)
     end
     switch x, case 1, disp(1), case 2, disp(2), otherwise, disp(0); end
 %   ^^^^^^ keyword.control.switch.matlab
-%          ^ variable.other.constant.matlab
+%          ^ meta.switch.declaration.matlab
 %           ^ punctuation.separator.comma.matlab
 %             ^^^^ keyword.control.switch.case.matlab
 %                  ^ constant.numeric.decimal.matlab

--- a/test/t64SwitchStatements.m
+++ b/test/t64SwitchStatements.m
@@ -1,0 +1,125 @@
+% SYNTAX TEST "source.matlab"  "SwitchStatements: https://github.com/mathworks/MATLAB-Language-grammar/pull/64"
+
+
+
+% https://github.com/mathworks/MATLAB-Language-grammar/issues/45
+switch(letter)
+% <----- keyword.control.switch.matlab
+%     ^^^^^^^^ meta.switch.declaration.matlab
+    case {'A', 'B', 'C'}
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^^^^^^^^^^^^^^ meta.case.declaration.matlab  
+        return;
+    case {'D', 'E', 'F'}
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^^^^^^^^^^^^^^ meta.case.declaration.matlab  
+        return;
+    case 'X'
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^ meta.case.declaration.matlab  
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^ meta.case.declaration.matlab  
+        return;
+    case 'Y'
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^ meta.case.declaration.matlab  
+        return;
+    case 'Z'
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^ meta.case.declaration.matlab  
+        return;
+    otherwise
+%   ^^^^^^^^^ keyword.control.switch.otherwise.matlab
+        return;
+end
+% <-- keyword.control.end.switch.matlab
+
+
+% https://github.com/mathworks/MATLAB-Language-grammar/issues/47
+switch obj.memberVariable
+% <----- keyword.control.switch.matlab
+%      ^^^^^^^^^^^^^^^^^^ meta.switch.declaration.matlab
+    case { 0, 1, 2 }
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^^^^^^^^^ meta.case.declaration.matlab  
+        disp( 'dummy output - 0' );
+    case 3
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^ meta.case.declaration.matlab  
+        disp( 'dummy output - 1' );
+    otherwise
+%   ^^^^^^^^^ keyword.control.switch.otherwise.matlab
+        disp( 'dummy output - otherwise');
+
+end
+% <-- keyword.control.end.switch.matlab
+
+switch memberVariable
+% <----- keyword.control.switch.matlab
+%      ^^^^^^^^^^^^^^ meta.switch.declaration.matlab
+    case { 0, 1, 2 }
+        disp( 'dummy output - 0' );
+    case 3
+        disp( 'dummy output - 1' );
+    otherwise
+%   ^^^^^^^^^ keyword.control.switch.otherwise.matlab
+        disp( 'dummy output - otherwise' );
+end
+% <-- keyword.control.end.switch.matlab
+
+
+% https://github.com/mathworks/MATLAB-Language-grammar/issues/52
+switch input
+% <----- keyword.control.switch.matlab
+%      ^^^^^ meta.switch.declaration.matlab
+    case 0
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^ meta.case.declaration.matlab 
+        disp foo
+    case { 1,2}
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^^^^ meta.case.declaration.matlab 
+        disp bar
+    case {3,4 }
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^^^^ meta.case.declaration.matlab 
+        disp foobar
+    case {5,6}
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^^^ meta.case.declaration.matlab 
+        disp baz
+end
+% <-- keyword.control.end.switch.matlab
+
+
+% https://github.com/mathworks/MATLAB-Language-grammar/issues/64
+switch experiment
+% <----- keyword.control.switch.matlab
+%      ^^^^^^^^^^ meta.switch.declaration.matlab
+    case 0 % Script testing w/ artery only output, text here
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^ meta.case.declaration.matlab 
+%          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.percentage.matlab
+end
+% <-- keyword.control.end.switch.matlab
+
+
+a = @() 2;
+b = @() 2;
+
+switch a()
+% <----- keyword.control.switch.matlab
+%      ^^^ meta.switch.declaration.matlab
+    case 1
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^ meta.case.declaration.matlab 
+        disp("yes")
+    case b()
+%   ^^^^ keyword.control.switch.case.matlab
+%        ^^^ meta.case.declaration.matlab 
+        disp("wierd")
+    otherwise
+%   ^^^^^^^^^ keyword.control.switch.otherwise.matlab
+        disp("no")
+end
+% <-- keyword.control.end.switch.matlab


### PR DESCRIPTION
Fixes #45
Fixes #47
Fixes #52
Fixes #64

Switch statements are syntactically the same as if/elseif/else.

| switch                | if                   |
|-----------------------|----------------------|
| `switch` keyword      | `if` keyword         |
| switch declaration    | if declaration       |
| -                     | if statements        |
| `case` keyword        | `elseif` keyword     |
| case declaration      | elseif declaration   |
| case statements       | elseif statements    |
| `otherwise` keyword   | `else` keyword       |
| otherwise statements  | else statements      |
| `end` keyword         | `end` keyword        |

This PR copies the implementation from #82 and replaces the tokens with the ones for switch. 