### PR TITLE
Fix broken attribute parsing in classdef.

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -785,8 +785,8 @@
 								<dict>
 									<key>name</key>
 									<string>storage.modifier.section.class.matlab</string>
-									<!-- <key>comment</key> -->
-									<!-- <string>This breaks if there is a line continuation between end of attrs and name, but works for line continuations inside attrs. Line continuations are a mistake.</string> -->
+									<key>comment</key>
+									<string>This breaks if there is a line continuation between end of attrs and name, but works for line continuations inside attrs. Line continuations are a mistake.</string>
 									<key>begin</key>
 									<string>\G\(</string>
 									<key>end</key>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -783,78 +783,87 @@
 							<key>patterns</key>
 							<array>
 								<dict>
+									<key>name</key>
+									<string>storage.modifier.section.class.matlab</string>
+									<!-- <key>comment</key> -->
+									<!-- <string>This breaks if there is a line continuation between end of attrs and name, but works for line continuations inside attrs. Line continuations are a mistake.</string> -->
 									<key>begin</key>
-									<string>\G\s*(\((.|\s)*\))?(?=\s* \w+)\s*(\w+)\s*</string>
-									<key>beginCaptures</key>
-									<dict>
-										<key>1</key>
+									<string>\G\(</string>
+									<key>end</key>
+									<string>\)(?=\s*\w+)</string>
+									<key>patterns</key>
+									<array>
 										<dict>
-											<key>comment</key>
-											<string>Optional attributes</string>
+											<key>name</key>
+											<string>punctuation.separator.modifier.comma.matlab</string>
+											<key>match</key>
+											<string>,</string>
+										</dict>
+										<dict>
+											<key>name</key>
+											<string>storage.modifier.class.matlab</string>
+											<key>match</key>
+											<string>[a-zA-Z][a-zA-Z0-9_]*</string>
+										</dict>
+										<dict>
+											<key>begin</key>
+											<string>(=)\s*</string>
+											<key>beginCaptures</key>
+											<dict>
+												<key>1</key>
+												<dict>
+													<key>name</key>
+													<string>keyword.operator.assignment.matlab</string>
+												</dict>
+											</dict>
+											<key>end</key>
+											<string>(?=\)|,)</string>
 											<key>patterns</key>
 											<array>
 												<dict>
 													<key>name</key>
-													<string>punctuation.section.parens.begin.matlab</string>
+													<string>constant.language.boolean.matlab</string>
 													<key>match</key>
-													<string>(?&lt;=\s)\(</string>
-												</dict>
-												<dict>
-													<key>name</key>
-													<string>punctuation.section.parens.end.matlab</string>
-													<key>match</key>
-													<string>\)\z</string>
-												</dict>
-												<dict>
-													<key>name</key>
-													<string>punctuation.separator.modifier.comma.matlab</string>
-													<key>match</key>
-													<string>,</string>
-												</dict>
-												<dict>
-													<key>name</key>
-													<string>storage.modifier.class.matlab</string>
-													<key>match</key>
-													<string>[a-zA-Z][a-zA-Z0-9_]*</string>
-												</dict>
-												<dict>
-													<key>begin</key>
-													<string>(=)\s*</string>
-													<key>beginCaptures</key>
-													<dict>
-														<key>1</key>
-														<dict>
-															<key>name</key>
-															<string>keyword.operator.assignment.matlab</string>
-														</dict>
-													</dict>
-													<key>end</key>
-													<string>(?=\)|,)</string>
-													<key>patterns</key>
-													<array>
-														<dict>
-															<key>name</key>
-															<string>constant.language.boolean.matlab</string>
-															<key>match</key>
-															<string>true|false</string>
-														</dict>
-														<dict>
-															<key>include</key>
-															<string>#string</string>
-														</dict>
-													</array>
+													<string>true|false</string>
 												</dict>
 												<dict>
 													<key>include</key>
-													<string>#comments</string>
+													<string>#string</string>
 												</dict>
 												<dict>
 													<key>include</key>
-													<string>#line_continuation</string>
+													<string>#curly_brackets</string>
+												</dict>
+												<dict>
+													<key>include</key>
+													<string>#line_continuations</string>
 												</dict>
 											</array>
 										</dict>
-										<key>3</key>
+										<dict>
+											<key>include</key>
+											<string>#comments</string>
+										</dict>
+										<dict>
+											<key>include</key>
+											<string>#line_continuation</string>
+										</dict>
+										<dict>
+											<key>include</key>
+											<string>#comments</string>
+										</dict>
+										<dict>
+											<key>include</key>
+											<string>#line_continuation</string>
+										</dict>
+									</array>
+								</dict>
+								<dict>
+									<key>begin</key>
+									<string>\s*(\w+)</string>
+									<key>beginCaptures</key>
+									<dict>
+										<key>1</key>
 										<dict>
 											<key>comment</key>
 											<string>Class name</string>
@@ -862,21 +871,13 @@
 											<string>entity.name.type.class.matlab</string>
 										</dict>
 									</dict>
+									<key>end</key>
+									<string>(?&lt;!\.{3})(?=\s*%|\n)</string>
 									<key>patterns</key>
 									<array>
 										<dict>
 											<key>begin</key>
 											<string>\G</string>
-											<key>beginCaptures</key>
-											<dict>
-												<key>1</key>
-												<dict>
-													<key>comment</key>
-													<string>Class name</string>
-													<key>name</key>
-													<string>entity.name.type.class.matlab</string>
-												</dict>
-											</dict>
 											<key>end</key>
 											<string>(?&lt;!\.{3})(?=\n)</string>
 											<key>patterns</key>
@@ -947,8 +948,6 @@
 											<string>#line_continuation</string>
 										</dict>
 									</array>
-									<key>end</key>
-									<string>(?&lt;!\.{3})(?=\s*%|\n)</string>
 								</dict>
 							</array>
 						</dict>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -912,6 +912,14 @@
 											<key>patterns</key>
 											<array>
 												<dict>
+													<key>include</key>
+													<string>#comments</string>
+												</dict>
+												<dict>
+													<key>include</key>
+													<string>#line_continuation</string>
+												</dict>
+												<dict>
 													<key>comment</key>
 													<string>Optional inheritance operator</string>
 													<key>name</key>
@@ -958,14 +966,6 @@
 													<key>match</key>
 													<string>&amp;</string>
 												</dict>
-												<dict>
-													<key>include</key>
-													<string>#comments</string>
-												</dict>
-												<dict>
-													<key>include</key>
-													<string>#line_continuation</string>
-												</dict>
 											</array>
 										</dict>
 										<dict>
@@ -977,6 +977,10 @@
 											<string>#line_continuation</string>
 										</dict>
 									</array>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#comments</string>
 								</dict>
 							</array>
 						</dict>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -784,7 +784,7 @@
 							<array>
 								<dict>
 									<key>begin</key>
-									<string>\G(\([^)]*\))?\s*</string>
+									<string>\G\s*(\((.|\s)*\))?(?=\s* \w+)\s*(\w+)\s*</string>
 									<key>beginCaptures</key>
 									<dict>
 										<key>1</key>
@@ -854,12 +854,19 @@
 												</dict>
 											</array>
 										</dict>
+										<key>3</key>
+										<dict>
+											<key>comment</key>
+											<string>Class name</string>
+											<key>name</key>
+											<string>entity.name.type.class.matlab</string>
+										</dict>
 									</dict>
 									<key>patterns</key>
 									<array>
 										<dict>
 											<key>begin</key>
-											<string>\G\s*([a-zA-Z][a-zA-Z0-9_]*)</string>
+											<string>\G</string>
 											<key>beginCaptures</key>
 											<dict>
 												<key>1</key>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -836,7 +836,7 @@
 												</dict>
 												<dict>
 													<key>include</key>
-													<string>#line_continuations</string>
+													<string>#line_continuation</string>
 												</dict>
 											</array>
 										</dict>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -827,6 +827,43 @@
 													<string>true|false</string>
 												</dict>
 												<dict>
+													<key>name</key>
+													<string>meta.metaclass.matlab</string>
+													<key>begin</key>
+													<string>(\?)</string>
+													<key>beginCaptures</key>
+													<dict>
+														<key>1</key>
+														<dict>
+															<key>name</key>
+															<string>keyword.operator.other.question.matlab</string>
+														</dict>
+													</dict>
+													<key>end</key>
+													<string>(?=\)|,)</string>
+													<key>patterns</key>
+													<array>
+														<dict>
+															<key>name</key>
+															<string>entity.other.class.matlab</string>
+															<key>match</key>
+															<string>(?&lt;=[\s.&lt;])[a-zA-Z][a-zA-Z0-9_]*(?=\s|,|\))</string>
+														</dict>
+														<dict>
+															<key>name</key>
+															<string>entity.name.namespace.matlab</string>
+															<key>match</key>
+															<string>[a-zA-Z][a-zA-Z0-9_]*</string>
+														</dict>
+														<dict>
+															<key>name</key>
+															<string>punctuation.accessor.dot.matlab</string>
+															<key>match</key>
+															<string>\.</string>
+														</dict>
+													</array>
+												</dict>
+												<dict>
 													<key>include</key>
 													<string>#string</string>
 												</dict>
@@ -839,14 +876,6 @@
 													<string>#line_continuation</string>
 												</dict>
 											</array>
-										</dict>
-										<dict>
-											<key>include</key>
-											<string>#comments</string>
-										</dict>
-										<dict>
-											<key>include</key>
-											<string>#line_continuation</string>
 										</dict>
 										<dict>
 											<key>include</key>

--- a/test/t87ClassAttributes.m
+++ b/test/t87ClassAttributes.m
@@ -1,0 +1,5 @@
+classdef (AllowedSubclasses = {?SubClass1,?SubClass2}) SuperClass
+%        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ storage.modifier.section.class.matlab
+%                             ^^^^^^^^^^^^^^^^^^^^^^^ meta.cell.literal.matlab
+%                                                      ^^^^^^^^^^ entity.name.type.class.matlab
+end

--- a/test/t87ClassAttributes.m
+++ b/test/t87ClassAttributes.m
@@ -1,5 +1,6 @@
+% SYNTAX TEST "source.matlab"  "Property validation: https://github.com/mathworks/MATLAB-Language-grammar/issues/87"
 classdef (AllowedSubclasses = {?SubClass1,?SubClass2}) SuperClass
 %        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ storage.modifier.section.class.matlab
-%                             ^^^^^^^^^^^^^^^^^^^^^^^ meta.cell.literal.matlab
+%                              ^^^^^^^^^^^^^^^^^^^^^ meta.cell.literal.matlab
 %                                                      ^^^^^^^^^^ entity.name.type.class.matlab
 end


### PR DESCRIPTION
Resolves #87 

This still is not entirely correct however it fails only in the case where the end of the attribute block is separated by newline (and line continuation) from the `ClassName`. Making a fully correct TextMate compatible grammar seems impossible due to the ability to arbitrarily place line continuations, however this is a closer approximation and improves the usability of this grammar for further machine interaction e.g. https://github.com/sphinx-contrib/matlabdomain

Note: #86 must go in first.