### PR TITLE
Correct metaclass parsing

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -831,41 +831,16 @@
 													<string>true|false</string>
 												</dict>
 												<dict>
+													<key>comment</key>
+													<string>Metadata query for class properties</string>
 													<key>name</key>
-													<string>meta.metaclass.matlab</string>
-													<key>begin</key>
-													<string>(\?)</string>
-													<key>beginCaptures</key>
-													<dict>
-														<key>1</key>
-														<dict>
-															<key>name</key>
-															<string>keyword.operator.other.question.matlab</string>
-														</dict>
-													</dict>
-													<key>end</key>
-													<string>(?=\)|,)</string>
-													<key>patterns</key>
-													<array>
-														<dict>
-															<key>name</key>
-															<string>entity.other.class.matlab</string>
-															<key>match</key>
-															<string>(?&lt;=[\s.&lt;])[a-zA-Z][a-zA-Z0-9_]*(?=\s|,|\))</string>
-														</dict>
-														<dict>
-															<key>name</key>
-															<string>entity.name.namespace.matlab</string>
-															<key>match</key>
-															<string>[a-zA-Z][a-zA-Z0-9_]*</string>
-														</dict>
-														<dict>
-															<key>name</key>
-															<string>punctuation.accessor.dot.matlab</string>
-															<key>match</key>
-															<string>\.</string>
-														</dict>
-													</array>
+													<string>keyword.operator.other.question.matlab</string>
+													<key>match</key>
+													<string>(?&lt;!\w)\?(?=\w)</string>
+												</dict>
+												<dict>
+													<key>include</key>
+													<string>#metaclass_literal</string>
 												</dict>
 												<dict>
 													<key>include</key>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -114,6 +114,10 @@
 					<key>include</key>
 					<string>#curly_brackets</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#metaclass_literal</string>
+				</dict>
 			</array>
 		</dict>
 		<key>rules_after_command_dual</key>
@@ -2992,7 +2996,7 @@
 			<key>name</key>
 			<string>variable.other.readwrite.matlab</string>
 			<key>match</key>
-			<string>(?&lt;![a-zA-Z0-9_]|\.)[a-zA-Z][a-zA-Z0-9_]*(?![a-zA-Z0-9_]|(?:\(|\{|\.\())</string>
+			<string>(?&lt;![a-zA-Z0-9_]|\.|\?)[a-zA-Z][a-zA-Z0-9_]*(?![a-zA-Z0-9_]|(?:\(|\{|\.\())</string>
 		</dict>
 		<key>property_access</key>
 		<dict>
@@ -3002,6 +3006,32 @@
 			<string>punctuation.accessor.dot.matlab</string>
 			<key>match</key>
 			<string>\.</string>
+		</dict>
+		<key>metaclass_literal</key>
+		<dict>
+			<key>comment</key>
+			<string>Accessing a metaclass via the ? operator</string>
+			<key>name</key>
+			<string>meta.metaclass.matlab</string>
+			<key>begin</key>
+			<string>(?&lt;=\?)(?=[a-zA-Z])</string>
+			<key>end</key>
+			<string>(?&lt;=[a-zA-Z0-9_])(?![a-zA-Z0-9_]|\.|\(|{)</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>name</key>
+					<string>entity.other.class.matlab</string>
+					<key>match</key>
+					<string>(?&lt;=[.\?])[a-zA-Z][a-zA-Z0-9_]*(?![a-zA-Z0-9_.])</string>
+				</dict>
+				<dict>
+					<key>name</key>
+					<string>entity.name.namespace.matlab</string>
+					<key>match</key>
+					<string>[a-zA-Z][a-zA-Z0-9_]*</string>
+				</dict>
+			</array>
 		</dict>
 	</dict>
 </dict>

--- a/test/t89MetaclassLiterals.m
+++ b/test/t89MetaclassLiterals.m
@@ -1,0 +1,17 @@
+% SYNTAX TEST "source.matlab"  "Property validation: https://github.com/mathworks/MATLAB-Language-grammar/issues/89"
+classdef (AllowedSubclasses = {?SubClass1,?namespace1.SubClass2}) SuperClass
+%                               ^^^^^^^^^ meta.metaclass.matlab entity.other.class.matlab
+%                                          ^^^^^^^^^^^^^^^^^^^^ meta.metaclass.matlab
+%                                          ^^^^^^^^^^ entity.name.namespace.matlab
+%                                                     ^^^^^^^^^ entity.other.class.matlab
+    methods
+        function foo()
+            x = ?namespace2.cls
+%                ^^^^^^^^^^^^^^ meta.metaclass.matlab
+%                ^^^^^^^^^^ entity.name.namespace.matlab
+%                           ^^^ entity.other.class.matlab
+            y = ?MyClass
+%                ^^^^^^^ meta.metaclass.matlab entity.other.class.matlab
+        end
+    end
+end

--- a/test/t89MetaclassLiterals.m
+++ b/test/t89MetaclassLiterals.m
@@ -1,4 +1,4 @@
-% SYNTAX TEST "source.matlab"  "Property validation: https://github.com/mathworks/MATLAB-Language-grammar/issues/89"
+% SYNTAX TEST "source.matlab"  "Metaclasses: https://github.com/mathworks/MATLAB-Language-grammar/issues/89"
 classdef (AllowedSubclasses = {?SubClass1,?namespace1.SubClass2}) SuperClass
 %                               ^^^^^^^^^ meta.metaclass.matlab entity.other.class.matlab
 %                                          ^^^^^^^^^^^^^^^^^^^^ meta.metaclass.matlab


### PR DESCRIPTION
Add functionality to correctly identify `?namespace.class` metaclass references everywhere.

Resolves #89 