### PR TITLE
fixed attribute parsing in properties methods and events

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -993,6 +993,12 @@
 									<array>
 										<dict>
 											<key>name</key>
+											<string>punctuation.separator.modifier.comma.matlab</string>
+											<key>match</key>
+											<string>,</string>
+										</dict>
+										<dict>
+											<key>name</key>
 											<string>storage.modifier.properties.matlab</string>
 											<key>match</key>
 											<string>[a-zA-Z][a-zA-Z0-9_]*</string>
@@ -1009,7 +1015,7 @@
 												</dict>
 											</dict>
 											<key>end</key>
-											<string>,|(?=\))</string>
+											<string>(?=\)|,)</string>
 											<key>patterns</key>
 											<array>
 												<dict>
@@ -1022,7 +1028,17 @@
 													<key>name</key>
 													<string>storage.modifier.access.matlab</string>
 													<key>match</key>
-													<string>public|protected|private</string>
+													<string>public|protected|private|immutable</string>
+												</dict>
+												<dict>
+													<key>include</key>
+													<string>#curly_brackets</string>
+												</dict>
+												<dict>
+													<key>name</key>
+													<string>constant.integer.matlab</string>
+													<key>match</key>
+													<string>[0-9]+</string>
 												</dict>
 											</array>
 										</dict>
@@ -1077,15 +1093,29 @@
 									<array>
 										<dict>
 											<key>name</key>
+											<string>punctuation.separator.modifier.comma.matlab</string>
+											<key>match</key>
+											<string>,</string>
+										</dict>
+										<dict>
+											<key>name</key>
 											<string>storage.modifier.methods.matlab</string>
 											<key>match</key>
 											<string>[a-zA-Z][a-zA-Z0-9_]*</string>
 										</dict>
 										<dict>
 											<key>begin</key>
-											<string>=\s*</string>
+											<string>(=)\s*</string>
 											<key>end</key>
-											<string>,|(?=\))</string>
+											<string>(?=\)|,)</string>
+											<key>beginCaptures</key>
+											<dict>
+												<key>1</key>
+												<dict>
+													<key>name</key>
+													<string>keyword.operator.assignment.matlab</string>
+												</dict>
+											</dict>
 											<key>patterns</key>
 											<array>
 												<dict>
@@ -1099,6 +1129,10 @@
 													<string>storage.modifier.access.matlab</string>
 													<key>match</key>
 													<string>public|protected|private</string>
+												</dict>
+												<dict>
+													<key>include</key>
+													<string>#curly_brackets</string>
 												</dict>
 											</array>
 										</dict>
@@ -1149,15 +1183,29 @@
 									<array>
 										<dict>
 											<key>name</key>
-											<string>variable.parameter.events.matlab</string>
+											<string>punctuation.separator.modifier.comma.matlab</string>
+											<key>match</key>
+											<string>,</string>
+										</dict>
+										<dict>
+											<key>name</key>
+											<string>storage.modifier.events.matlab</string>
 											<key>match</key>
 											<string>[a-zA-Z][a-zA-Z0-9_]*</string>
 										</dict>
 										<dict>
 											<key>begin</key>
-											<string>=\s*</string>
+											<string>(=)\s*</string>
+											<key>beginCaptures</key>
+											<dict>
+												<key>1</key>
+												<dict>
+													<key>name</key>
+													<string>keyword.operator.assignment.matlab</string>
+												</dict>
+											</dict>
 											<key>end</key>
-											<string>,|(?=\))</string>
+											<string>(?=\)|,)</string>
 											<key>patterns</key>
 											<array>
 												<dict>
@@ -1171,6 +1219,10 @@
 													<string>storage.modifier.access.matlab</string>
 													<key>match</key>
 													<string>public|protected|private</string>
+												</dict>
+												<dict>
+													<key>include</key>
+													<string>#curly_brackets</string>
 												</dict>
 											</array>
 										</dict>

--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -1019,6 +1019,10 @@
 											<key>patterns</key>
 											<array>
 												<dict>
+													<key>include</key>
+													<string>#string</string>
+												</dict>
+												<dict>
 													<key>name</key>
 													<string>constant.language.boolean.matlab</string>
 													<key>match</key>
@@ -1033,6 +1037,10 @@
 												<dict>
 													<key>include</key>
 													<string>#curly_brackets</string>
+												</dict>
+												<dict>
+													<key>include</key>
+													<string>#metaclass_literal</string>
 												</dict>
 												<dict>
 													<key>name</key>
@@ -1119,6 +1127,10 @@
 											<key>patterns</key>
 											<array>
 												<dict>
+													<key>include</key>
+													<string>#string</string>
+												</dict>
+												<dict>
 													<key>name</key>
 													<string>constant.language.boolean.matlab</string>
 													<key>match</key>
@@ -1128,11 +1140,21 @@
 													<key>name</key>
 													<string>storage.modifier.access.matlab</string>
 													<key>match</key>
-													<string>public|protected|private</string>
+													<string>public|protected|private|immutable</string>
 												</dict>
 												<dict>
 													<key>include</key>
 													<string>#curly_brackets</string>
+												</dict>
+												<dict>
+													<key>include</key>
+													<string>#metaclass_literal</string>
+												</dict>
+												<dict>
+													<key>name</key>
+													<string>constant.integer.matlab</string>
+													<key>match</key>
+													<string>[0-9]+</string>
 												</dict>
 											</array>
 										</dict>
@@ -1209,6 +1231,10 @@
 											<key>patterns</key>
 											<array>
 												<dict>
+													<key>include</key>
+													<string>#string</string>
+												</dict>
+												<dict>
 													<key>name</key>
 													<string>constant.language.boolean.matlab</string>
 													<key>match</key>
@@ -1218,11 +1244,21 @@
 													<key>name</key>
 													<string>storage.modifier.access.matlab</string>
 													<key>match</key>
-													<string>public|protected|private</string>
+													<string>public|protected|private|immutable</string>
 												</dict>
 												<dict>
 													<key>include</key>
 													<string>#curly_brackets</string>
+												</dict>
+												<dict>
+													<key>include</key>
+													<string>#metaclass_literal</string>
+												</dict>
+												<dict>
+													<key>name</key>
+													<string>constant.integer.matlab</string>
+													<key>match</key>
+													<string>[0-9]+</string>
 												</dict>
 											</array>
 										</dict>

--- a/test/snap/Account.m.snap
+++ b/test/snap/Account.m.snap
@@ -355,9 +355,10 @@
 #^^^^ source.matlab meta.class.matlab meta.events.matlab
 #    ^^^^^^ source.matlab meta.class.matlab meta.events.matlab keyword.control.events.matlab
 #          ^^ source.matlab meta.class.matlab meta.events.matlab
-#            ^^^^^^^^^^^^ source.matlab meta.class.matlab meta.events.matlab variable.parameter.events.matlab
+#            ^^^^^^^^^^^^ source.matlab meta.class.matlab meta.events.matlab storage.modifier.events.matlab
 #                        ^ source.matlab meta.class.matlab meta.events.matlab
-#                         ^^ source.matlab meta.class.matlab meta.events.matlab
+#                         ^ source.matlab meta.class.matlab meta.events.matlab keyword.operator.assignment.matlab
+#                          ^ source.matlab meta.class.matlab meta.events.matlab
 #                           ^^^^^^^^^ source.matlab meta.class.matlab meta.events.matlab storage.modifier.access.matlab
 #                                    ^^ source.matlab meta.class.matlab meta.events.matlab
 #                                      ^ source.matlab meta.class.matlab meta.events.matlab comment.line.percentage.matlab punctuation.definition.comment.matlab

--- a/test/snap/PropertyValidation.m.snap
+++ b/test/snap/PropertyValidation.m.snap
@@ -10,18 +10,18 @@
 #                         ^ source.matlab meta.class.matlab meta.properties.matlab
 #                          ^ source.matlab meta.class.matlab meta.properties.matlab keyword.operator.assignment.matlab
 #                           ^ source.matlab meta.class.matlab meta.properties.matlab
-#                            ^ source.matlab meta.class.matlab meta.properties.matlab
-#                             ^^^^^^ source.matlab meta.class.matlab meta.properties.matlab storage.modifier.access.matlab
-#                                   ^ source.matlab meta.class.matlab meta.properties.matlab
-#                                    ^ source.matlab meta.class.matlab meta.properties.matlab
+#                            ^ source.matlab meta.class.matlab meta.properties.matlab string.quoted.single.matlab punctuation.definition.string.begin.matlab
+#                             ^^^^^^ source.matlab meta.class.matlab meta.properties.matlab string.quoted.single.matlab
+#                                   ^ source.matlab meta.class.matlab meta.properties.matlab string.quoted.single.matlab punctuation.definition.string.end.matlab
+#                                    ^ source.matlab meta.class.matlab meta.properties.matlab punctuation.separator.modifier.comma.matlab
 #                                     ^ source.matlab meta.class.matlab meta.properties.matlab
 #                                      ^^^^^^^^^ source.matlab meta.class.matlab meta.properties.matlab storage.modifier.properties.matlab
 #                                               ^ source.matlab meta.class.matlab meta.properties.matlab
 #                                                ^ source.matlab meta.class.matlab meta.properties.matlab keyword.operator.assignment.matlab
 #                                                 ^ source.matlab meta.class.matlab meta.properties.matlab
-#                                                  ^ source.matlab meta.class.matlab meta.properties.matlab
-#                                                   ^^^^^^^ source.matlab meta.class.matlab meta.properties.matlab storage.modifier.access.matlab
-#                                                          ^ source.matlab meta.class.matlab meta.properties.matlab
+#                                                  ^ source.matlab meta.class.matlab meta.properties.matlab string.quoted.single.matlab punctuation.definition.string.begin.matlab
+#                                                   ^^^^^^^ source.matlab meta.class.matlab meta.properties.matlab string.quoted.single.matlab
+#                                                          ^ source.matlab meta.class.matlab meta.properties.matlab string.quoted.single.matlab punctuation.definition.string.end.matlab
 #                                                           ^^ source.matlab meta.class.matlab meta.properties.matlab
 >        % Commentary in the properties block
 #^^^^^^^^ source.matlab meta.class.matlab meta.properties.matlab punctuation.whitespace.comment.leading.matlab

--- a/test/snap/controlFlow.m.snap
+++ b/test/snap/controlFlow.m.snap
@@ -120,7 +120,7 @@
 #^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab
 #    ^^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab keyword.control.elseif.matlab
 #          ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab
-#           ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab variable.other.readwrite.matlab 
+#           ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab variable.other.readwrite.matlab
 #            ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab
 #             ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab keyword.operator.relational.matlab
 #              ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.elseif.matlab meta.elseif.declaration.matlab
@@ -147,7 +147,7 @@
 #                      ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab meta.function-call.parens.matlab punctuation.section.parens.end.matlab
 #                       ^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab punctuation.terminator.semicolon.matlab
 >    end
-#^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab 
+#^^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab meta.else.matlab
 #    ^^^ source.matlab meta.function.matlab meta.try.matlab meta.if.matlab keyword.control.end.if.matlab
 >catch ME
 #^^^^^ source.matlab meta.function.matlab meta.try.matlab meta.catch.matlab keyword.control.catch.matlab

--- a/test/snap/lineContinuations.m.snap
+++ b/test/snap/lineContinuations.m.snap
@@ -78,7 +78,7 @@
 #             ^^^^^^^ source.matlab meta.function-call.parens.matlab meta.continuation.line.matlab comment.continuation.line.matlab
 >    arg2 ... comment
 #^^^^ source.matlab meta.function-call.parens.matlab
-#    ^^^^ source.matlab meta.function-call.parens.matlab variable.other.readwrite.matlab 
+#    ^^^^ source.matlab meta.function-call.parens.matlab variable.other.readwrite.matlab
 #        ^ source.matlab meta.function-call.parens.matlab
 #         ^^^ source.matlab meta.function-call.parens.matlab meta.continuation.line.matlab punctuation.separator.continuation.line.matlab
 #            ^^^^^^^^ source.matlab meta.function-call.parens.matlab meta.continuation.line.matlab comment.continuation.line.matlab

--- a/test/t08PropertyValidation.m
+++ b/test/t08PropertyValidation.m
@@ -3,10 +3,10 @@ classdef t08PropertyValidation
     properties (GetAccess = 'public', SetAccess = 'private')
 %               ^^^^^^^^^ storage.modifier.properties.matlab
 %                         ^ keyword.operator.assignment.matlab
-%                            ^^^^^^ storage.modifier.access.matlab
+%                           ^^^^^^^^ string.quoted.single.matlab
 %                                     ^^^^^^^^^ storage.modifier.properties.matlab
 %                                               ^ keyword.operator.assignment.matlab
-%                                                  ^^^^^^^ storage.modifier.access.matlab
+%                                                 ^^^^^^^^^ string.quoted.single.matlab
         % Commentary in the properties block
 %       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.percentage.matlab
         Prop % comment

--- a/test/t95AttributeParsing.m
+++ b/test/t95AttributeParsing.m
@@ -1,0 +1,15 @@
+% SYNTAX TEST "source.matlab"  "Property etc. attribute parsing: https://github.com/mathworks/MATLAB-Language-grammar/issues/95"
+classdef Class
+    % Some properties
+    properties (SetAccess=public, GetAccess={?foo.bar.baz})
+%                                            ^^^^^^^^^^^^ meta.cell.literal.matlab
+    end
+
+    events (Hidden=true, ListenAccess={?foo.bar}, NotifyAccess=?bar.baz)
+%                                      ^^^^^^^^ meta.cell.literal.matlab
+    end
+
+    methods (Access=?bar.baz, Abstract=false)
+%                    ^^^^^^^ meta.metaclass.matlab
+    end
+end


### PR DESCRIPTION
This extends the work in #88 to also improve parsing of `property`, `events`, and `methods` blocks.

WIP until tests are updated.