### PR TITLE
Fix grammar when there is a line continuation after class attributes

### DIFF
--- a/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
+++ b/Matlab.tmbundle/Syntaxes/MATLAB.tmLanguage
@@ -789,12 +789,10 @@
 								<dict>
 									<key>name</key>
 									<string>storage.modifier.section.class.matlab</string>
-									<key>comment</key>
-									<string>This breaks if there is a line continuation between end of attrs and name, but works for line continuations inside attrs. Line continuations are a mistake.</string>
 									<key>begin</key>
 									<string>\G\(</string>
 									<key>end</key>
-									<string>\)(?=\s*\w+)</string>
+									<string>\)</string>
 									<key>patterns</key>
 									<array>
 										<dict>
@@ -960,6 +958,10 @@
 								<dict>
 									<key>include</key>
 									<string>#comments</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#line_continuation</string>
 								</dict>
 							</array>
 						</dict>

--- a/test/t93ContinuationAfterClassAttributes.m
+++ b/test/t93ContinuationAfterClassAttributes.m
@@ -1,0 +1,17 @@
+% SYNTAX TEST "source.matlab"  "Line continuation after class attributes: https://github.com/mathworks/MATLAB-Language-grammar/issues/93"
+
+% Case 1: Line continuation without attributes
+classdef ...
+%        ^^^ meta.class.declaration.matlab punctuation.separator.continuation.line.matlab
+    Class1
+%   ^^^^^^ meta.class.declaration.matlab entity.name.type.class.matlab
+end
+
+% Case 2: Line continuation with attributes
+classdef (Abstract) ...
+%        ^^^^^^^^^^^^^^ meta.class.declaration.matlab
+%        ^^^^^^^^^^ storage.modifier.section.class.matlab
+%                   ^^^ punctuation.separator.continuation.line.matlab
+    Class2
+%   ^^^^^^ meta.class.declaration.matlab entity.name.type.class.matlab
+end


### PR DESCRIPTION
This change resolves tokenization in the following case by allowing a line continuation to follow the attributes:

```matlab
classdef (Abstract) ...
    ClassName
end
```

Fixes #93 